### PR TITLE
Fix onQueueChanged callback not being called

### DIFF
--- a/lib/audio_service.dart
+++ b/lib/audio_service.dart
@@ -183,7 +183,7 @@ class AudioService {
           break;
         case 'onQueueChanged':
           if (_onQueueChanged != null) {
-            final List<Map> args = call.arguments;
+            final List<Map> args = List<Map>.from(call.arguments[0]);
             List<MediaItem> queue = args.map(_raw2mediaItem).toList();
             _onQueueChanged(queue);
           }


### PR DESCRIPTION
Because of a small issue, the `onQueueChanged` callback did not fire.
This should fix it. 