### PR TITLE
Don't show the notification creation time

### DIFF
--- a/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -191,7 +191,7 @@ public class AudioService extends MediaBrowserServiceCompat implements AudioMana
 				.setContentTitle(contentTitle)
 				.setContentText(contentText)
 				.setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-
+				.setShowWhen(false)
 				.setDeleteIntent(buildMediaButtonPendingIntent(PlaybackStateCompat.ACTION_STOP))
 				;
 		if (androidNotificationClickStartsActivity)


### PR DESCRIPTION
This resets every time the notification's updated, so it's useless.