### PR TITLE
Support to set and get ratings in MediaItems

### DIFF
--- a/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -323,26 +323,7 @@ public class AudioService extends MediaBrowserServiceCompat implements AudioMana
 		if (displayDescription != null)
 			builder.putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_DESCRIPTION, displayDescription);
 		if (rating != null) {
-			if (rating.get("value") != null) {
-				switch ((int) rating.get("type")) {
-					case RatingCompat.RATING_3_STARS:
-					case RatingCompat.RATING_4_STARS:
-					case RatingCompat.RATING_5_STARS:
-						builder.putRating(MediaMetadataCompat.METADATA_KEY_RATING, RatingCompat.newStarRating((int) rating.get("type"), (int) rating.get("value")));
-						break;
-					case RatingCompat.RATING_HEART:
-						builder.putRating(MediaMetadataCompat.METADATA_KEY_RATING, RatingCompat.newHeartRating((boolean) rating.get("value")));
-						break;
-                    case RatingCompat.RATING_PERCENTAGE:
-                        builder.putRating(MediaMetadataCompat.METADATA_KEY_RATING, RatingCompat.newPercentageRating((float) rating.get("value")));
-                        break;
-                    case RatingCompat.RATING_THUMB_UP_DOWN:
-                        builder.putRating(MediaMetadataCompat.METADATA_KEY_RATING, RatingCompat.newThumbRating((boolean) rating.get("value")));
-                        break;
-                }
-			} else {
-				builder.putRating(MediaMetadataCompat.METADATA_KEY_RATING, RatingCompat.newUnratedRating((int) rating.get("type")));
-			}
+			builder.putRating(MediaMetadataCompat.METADATA_KEY_RATING, AudioServicePlugin.raw2rating(rating));
 		}
 		MediaMetadataCompat mediaMetadata = builder.build();
 		mediaMetadataCache.put(mediaId, mediaMetadata);
@@ -693,6 +674,18 @@ public class AudioService extends MediaBrowserServiceCompat implements AudioMana
 			if (listener == null) return;
 			listener.onSeekTo(pos);
 		}
+
+		@Override
+		public void onSetRating(RatingCompat rating) {
+			if (listener == null) return;
+			listener.onSetRating(rating);
+		}
+
+		@Override
+		public void onSetRating(RatingCompat rating, Bundle extras) {
+			if (listener == null) return;
+			listener.onSetRating(rating, extras);
+		}
 	}
 
 	public static interface ServiceListener {
@@ -721,7 +714,8 @@ public class AudioService extends MediaBrowserServiceCompat implements AudioMana
 		void onRewind();
 		void onStop();
 		void onSeekTo(long pos);
-		//void onSetRating(RatingCompat rating);
+		void onSetRating(RatingCompat rating);
+		void onSetRating(RatingCompat rating, Bundle extras);
 		//void onSetRepeatMode(@PlaybackStateCompat.RepeatMode int repeatMode)
 		//void onSetShuffleModeEnabled(boolean enabled);
 		//void onSetShuffleMode(@PlaybackStateCompat.ShuffleMode int shuffleMode);

--- a/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
+++ b/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
@@ -1,38 +1,41 @@
 package com.ryanheise.audioservice;
 
+import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Context;
+import android.media.AudioFormat;
+import android.media.AudioManager;
+import android.media.AudioTrack;
+import android.os.Bundle;
+import android.os.RemoteException;
+import android.os.SystemClock;
+import android.support.v4.app.NotificationCompat;
+import android.support.v4.media.MediaBrowserCompat;
+import android.support.v4.media.MediaBrowserServiceCompat;
+import android.support.v4.media.MediaDescriptionCompat;
+import android.support.v4.media.MediaMetadataCompat;
+import android.support.v4.media.RatingCompat;
+import android.support.v4.media.session.MediaControllerCompat;
+import android.support.v4.media.session.MediaSessionCompat;
+import android.support.v4.media.session.PlaybackStateCompat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.flutter.app.FlutterApplication;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import io.flutter.app.FlutterApplication;
-import android.content.Context;
-import io.flutter.view.FlutterCallbackInformation;
-import io.flutter.view.FlutterNativeView;
-import io.flutter.view.FlutterMain;
-import io.flutter.view.FlutterRunArguments;
-import android.app.Activity;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
-import java.util.Arrays;
-import android.os.RemoteException;
-import android.os.SystemClock;
 import io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback;
-import android.support.v4.app.NotificationCompat;
-import android.support.v4.media.MediaBrowserCompat;
-import android.support.v4.media.MediaBrowserServiceCompat;
-import android.support.v4.media.session.MediaControllerCompat;
-import android.support.v4.media.session.MediaSessionCompat;
-import android.support.v4.media.MediaMetadataCompat;
-import android.support.v4.media.MediaDescriptionCompat;
-import android.content.ComponentName;
-import android.os.Bundle;
-import java.util.HashMap;
-import android.media.AudioManager;
-import android.media.AudioTrack;
-import android.media.AudioFormat;
-import android.support.v4.media.session.PlaybackStateCompat;
+import io.flutter.plugin.common.PluginRegistry.Registrar;
+import io.flutter.view.FlutterCallbackInformation;
+import io.flutter.view.FlutterMain;
+import io.flutter.view.FlutterNativeView;
+import io.flutter.view.FlutterRunArguments;
 
 /** AudioservicePlugin */
 public class AudioServicePlugin {
@@ -635,6 +638,34 @@ public class AudioServicePlugin {
 			raw.put("displaySubtitle", mediaMetadata.getText(MediaMetadataCompat.METADATA_KEY_DISPLAY_SUBTITLE).toString());
 		if (mediaMetadata.containsKey(MediaMetadataCompat.METADATA_KEY_DISPLAY_DESCRIPTION))
 			raw.put("displayDescription", mediaMetadata.getText(MediaMetadataCompat.METADATA_KEY_DISPLAY_DESCRIPTION).toString());
+		if (mediaMetadata.containsKey(MediaMetadataCompat.METADATA_KEY_RATING)) {
+			RatingCompat rating = mediaMetadata.getRating(MediaMetadataCompat.METADATA_KEY_RATING);
+			Map<String, Object> ratingRaw = new HashMap<String, Object>();
+			ratingRaw.put("type", rating.getRatingStyle());
+			if (rating.isRated()) {
+				switch (rating.getRatingStyle()) {
+					case RatingCompat.RATING_3_STARS:
+					case RatingCompat.RATING_4_STARS:
+					case RatingCompat.RATING_5_STARS:
+						ratingRaw.put("value", rating.getStarRating());
+						break;
+					case RatingCompat.RATING_HEART:
+						ratingRaw.put("value", rating.hasHeart());
+						break;
+					case RatingCompat.RATING_PERCENTAGE:
+						ratingRaw.put("value", rating.getPercentRating());
+						break;
+					case RatingCompat.RATING_THUMB_UP_DOWN:
+						ratingRaw.put("value", rating.isThumbUp());
+						break;
+					case RatingCompat.RATING_NONE:
+						ratingRaw.put("value", null);
+				}
+			} else {
+				ratingRaw.put("value", null);
+			}
+			raw.put("rating", ratingRaw);
+		}
 		return raw;
 	}
 
@@ -649,7 +680,8 @@ public class AudioServicePlugin {
 				(String)rawMediaItem.get("artUri"),
 				(String)rawMediaItem.get("displayTitle"),
 				(String)rawMediaItem.get("displaySubtitle"),
-				(String)rawMediaItem.get("displayDescription")
+				(String)rawMediaItem.get("displayDescription"),
+				(Map<String, Object>)rawMediaItem.get("rating")
 				);
 	}
 

--- a/lib/audio_service.dart
+++ b/lib/audio_service.dart
@@ -74,72 +74,73 @@ class PlaybackState {
   });
 }
 
-/// A rating to attach to a MediaItem.
-class Rating {
-  /// A rating style with 0 to 3 stars.
-  static const int RATING_3_STARS = 3;
-
-  /// A rating style with 0 to 4 stars.
-  static const int RATING_4_STARS = 4;
-
-  /// A rating style with 0 to 5 stars.
-  static const int RATING_5_STARS = 5;
-
-  /// A rating style with a single degree of rating, "heart" vs "no heart".
-  /// Can be used to indicate the content referred to is a favorite (or not).
-  static const int RATING_HEART = 1;
-
+enum RatingStyle {
   /// Indicates a rating style is not supported.
   /// A Rating will never have this type, but can be used by other classes
   /// to indicate they do not support Rating.
-  static const int RATING_NONE = 0;
+  RATING_NONE,
 
-  /// A rating style expressed as a percentage.
-  static const int RATING_PERCENTAGE = 6;
+  /// A rating style with a single degree of rating, "heart" vs "no heart".
+  /// Can be used to indicate the content referred to is a favorite (or not).
+  RATING_HEART,
 
   /// A rating style for "thumb up" vs "thumb down".
-  static const int RATING_THUMB_UP_DOWN = 2;
+  RATING_THUMB_UP_DOWN,
 
-  final int _type;
+  /// A rating style with 0 to 3 stars.
+  RATING_3_STARS,
+
+  /// A rating style with 0 to 4 stars.
+  RATING_4_STARS,
+
+  /// A rating style with 0 to 5 stars.
+  RATING_5_STARS,
+
+  /// A rating style expressed as a percentage.
+  RATING_PERCENTAGE,
+}
+
+/// A rating to attach to a MediaItem.
+class Rating {
+  final RatingStyle _type;
   dynamic _value;
 
   Rating._internal(this._type, this._value);
 
   /// Create a new heart rating.
-  Rating.newHeartRating(bool hasHeart) : this._internal(RATING_HEART, hasHeart);
+  Rating.newHeartRating(bool hasHeart) : this._internal(RatingStyle.RATING_HEART, hasHeart);
 
   /// Create a new percentage rating.
   factory Rating.newPercentageRating(double percent) {
     if (percent < 0 || percent > 100) throw ArgumentError();
-    return Rating._internal(RATING_PERCENTAGE, percent);
+    return Rating._internal(RatingStyle.RATING_PERCENTAGE, percent);
   }
 
   /// Create a new star rating.
-  factory Rating.newStartRating(int starRatingStyle, int starRating) {
-    if (starRatingStyle != RATING_3_STARS && starRatingStyle != RATING_4_STARS && starRatingStyle != RATING_5_STARS) {
+  factory Rating.newStartRating(RatingStyle starRatingStyle, int starRating) {
+    if (starRatingStyle != RatingStyle.RATING_3_STARS && starRatingStyle != RatingStyle.RATING_4_STARS && starRatingStyle != RatingStyle.RATING_5_STARS) {
       throw ArgumentError();
     }
-    if (starRating > starRatingStyle || starRating < 0) throw ArgumentError();
+    if (starRating > starRatingStyle.index || starRating < 0) throw ArgumentError();
     return Rating._internal(starRatingStyle, starRating);
   }
 
   /// Create a new thumb rating.
-  Rating.newThumbRating(bool isThumbsUp) : this._internal(RATING_THUMB_UP_DOWN, isThumbsUp);
+  Rating.newThumbRating(bool isThumbsUp) : this._internal(RatingStyle.RATING_THUMB_UP_DOWN, isThumbsUp);
 
   /// Create a new unrated rating.
-  factory Rating.newUnratedRating(int ratingStyle) {
-    if (ratingStyle < 0 || ratingStyle > 6) throw ArgumentError();
+  factory Rating.newUnratedRating(RatingStyle ratingStyle) {
     return Rating._internal(ratingStyle, null);
   }
 
   /// Return the rating style.
-  int getRatingStyle() => _type;
+  RatingStyle getRatingStyle() => _type;
 
   /// Returns a rating value greater or equal to 0.0f,
   /// or a negative value if the rating style is not percentage-based,
   /// or if it is unrated.
   double getPercentRating() {
-    if (_type != RATING_PERCENTAGE) return -1;
+    if (_type != RatingStyle.RATING_PERCENTAGE) return -1;
     if (_value < 0 || _value > 100) return -1;
     return _value ?? -1;
   }
@@ -147,7 +148,7 @@ class Rating {
   /// Returns a rating value greater or equal to 0.0f, or a
   /// negative value if the rating style is not star-based, or if it is unrated.
   int getStarRating() {
-    if (_type != RATING_3_STARS && _type != RATING_4_STARS && _type != RATING_5_STARS) return -1;
+    if (_type != RatingStyle.RATING_3_STARS && _type != RatingStyle.RATING_4_STARS && _type != RatingStyle.RATING_5_STARS) return -1;
     return _value ?? -1;
   }
 
@@ -155,7 +156,7 @@ class Rating {
   /// the rating is "heart unselected", if the rating style is
   /// not [RATING_HEART] or if it is unrated.
   bool hasHeart() {
-    if (_type != RATING_HEART) return false;
+    if (_type != RatingStyle.RATING_HEART) return false;
     return _value ?? false;
   }
 
@@ -163,7 +164,7 @@ class Rating {
   /// is "thumb down", if the rating style is not [RATING_THUMB_UP_DOWN]
   /// or if it is unrated.
   bool isThumbUp() {
-    if (_type != RATING_THUMB_UP_DOWN) return false;
+    if (_type != RatingStyle.RATING_THUMB_UP_DOWN) return false;
     return _value ?? false;
   }
 
@@ -172,13 +173,13 @@ class Rating {
 
   Map<String, dynamic> _toRaw() {
     return <String, dynamic>{
-      'type': _type,
+      'type': _type.index,
       'value': _value,
     };
   }
 
   // Even though this should take a Map<String, dynamic>, that makes an error.
-  Rating._fromRaw(Map<dynamic, dynamic> raw) : this._internal(raw['type'], raw['value']);
+  Rating._fromRaw(Map<dynamic, dynamic> raw) : this._internal(RatingStyle.values[raw['type']], raw['value']);
 }
 
 /// Metadata about an audio item that can be played, or a folder containing


### PR DESCRIPTION
A brief summary of what I've done:

- Wrote a Dart clone of the Android Support Library's [`RatingCompat`](https://developer.android.com/reference/android/support/v4/media/RatingCompat) class, that can also serialise and de-serialise using primitive `HashMap`s
- Added an optional `rating` property on the MediaItem class
- Modified the serialisation methods of `MediaItem`, both in Java and Dart, to include the `rating` property

This is half of issue #30 .