### PR TITLE
Use a normal constructor instead of a factory method to create an unrated Rating object

### DIFF
--- a/lib/audio_service.dart
+++ b/lib/audio_service.dart
@@ -131,9 +131,7 @@ class Rating {
   Rating.newThumbRating(bool isThumbsUp) : this._internal(RatingStyle.thumbUpDown, isThumbsUp);
 
   /// Create a new unrated rating.
-  factory Rating.newUnratedRating(RatingStyle ratingStyle) {
-    return Rating._internal(ratingStyle, null);
-  }
+  Rating.newUnratedRating(RatingStyle ratingStyle) : this._internal(ratingStyle, null);
 
   /// Return the rating style.
   RatingStyle getRatingStyle() => _type;


### PR DESCRIPTION
I accidentally left it like this after debugging.