### PR TITLE
Set metadata and state variables to null on stop

### DIFF
--- a/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
+++ b/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
@@ -580,6 +580,7 @@ public class AudioServicePlugin {
 				if (silenceAudioTrack != null)
 					silenceAudioTrack.release();
 				backgroundFlutterView = null;
+				invokeMethod("onStopped");
 				result.success(true);
 				break;
 			case "notifyChildrenChanged":

--- a/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
+++ b/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
@@ -580,7 +580,7 @@ public class AudioServicePlugin {
 				if (silenceAudioTrack != null)
 					silenceAudioTrack.release();
 				backgroundFlutterView = null;
-				invokeMethod("onStopped");
+				clientHandler.invokeMethod("onStopped");
 				result.success(true);
 				break;
 			case "notifyChildrenChanged":

--- a/lib/audio_service.dart
+++ b/lib/audio_service.dart
@@ -183,6 +183,20 @@ class Rating {
   Rating._fromRaw(Map<dynamic, dynamic> raw) : this._internal(RatingStyle.values[raw['type']], raw['value']);
 }
 
+StreamController<List<MediaItem>> _browseMediaChildrenController =
+      StreamController<List<MediaItem>>.broadcast();
+StreamController<PlaybackState> _playbackStateController =
+      StreamController<PlaybackState>.broadcast();
+StreamController<MediaItem> _currentMediaItemController =
+      StreamController<MediaItem>.broadcast();
+StreamController<List<MediaItem>> _queueController =
+      StreamController<List<MediaItem>>.broadcast();
+
+List<MediaItem> _browseMediaChildren;
+PlaybackState _playbackState;
+MediaItem _currentMediaItem;
+List<MediaItem> _queue;
+
 /// Metadata about an audio item that can be played, or a folder containing
 /// audio items.
 class MediaItem {
@@ -312,49 +326,33 @@ class AudioService {
   /// task.
   static const String MEDIA_ROOT_ID = "root";
 
-  static StreamController<List<MediaItem>> _browseMediaChildrenController =
-      StreamController<List<MediaItem>>.broadcast();
-
   /// A stream that broadcasts the children of the current browse
   /// media parent.
   static Stream<List<MediaItem>> get browseMediaChildrenStream =>
       _browseMediaChildrenController.stream;
 
-  static StreamController<PlaybackState> _playbackStateController =
-      StreamController<PlaybackState>.broadcast();
-
   /// A stream that broadcasts the playback state.
   static Stream<PlaybackState> get playbackStateStream =>
       _playbackStateController.stream;
 
-  static StreamController<MediaItem> _currentMediaItemController =
-      StreamController<MediaItem>.broadcast();
-
   /// A stream that broadcasts the current [MediaItem].
   static Stream<MediaItem> get currentMediaItemStream =>
       _currentMediaItemController.stream;
-
-  static StreamController<List<MediaItem>> _queueController =
-      StreamController<List<MediaItem>>.broadcast();
 
   /// A stream that broadcasts the queue.
   static Stream<List<MediaItem>> get queueStream => _queueController.stream;
 
   /// The children of the current browse media parent.
   static List<MediaItem> get browseMediaChildren => _browseMediaChildren;
-  static List<MediaItem> _browseMediaChildren;
 
   /// The current playback state.
   static PlaybackState get playbackState => _playbackState;
-  static PlaybackState _playbackState;
 
   /// The current media item.
   static MediaItem get currentMediaItem => _currentMediaItem;
-  static MediaItem _currentMediaItem;
 
   /// The current queue.
   static List<MediaItem> get queue => _queue;
-  static List<MediaItem> _queue;
 
   /// Connects to the service from your UI so that audio playback can be
   /// controlled.
@@ -793,6 +791,16 @@ class AudioServiceBackground {
     await _backgroundChannel.invokeMethod('ready', enableQueue);
     await onStart();
     await _backgroundChannel.invokeMethod('stopped');
+
+    _browseMediaChildren = null;
+    _browseMediaChildrenController.add(null);
+    _playbackState = null;
+    _playbackStateController.add(null);
+    _currentMediaItem = null;
+    _currentMediaItemController.add(null);
+    _queue = null;
+    _queueController.add(null);
+
     _backgroundChannel.setMethodCallHandler(null);
     _state = _noneState;
   }


### PR DESCRIPTION
This doesn't fully work; for some reason, stream subscriptions aren't notified when the `null` objects are added.