### PR TITLE
iOS: setup MPRemoteCommandCenter and AVAudioSession

### DIFF
--- a/ios/Classes/AudioServicePlugin.m
+++ b/ios/Classes/AudioServicePlugin.m
@@ -65,8 +65,9 @@ static MPRemoteCommandCenter *commandCenter = nil;
     [[AVAudioSession sharedInstance] setActive: YES error: nil];
     // Set callbacks on MPRemoteCommandCenter
     commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
-    [commandCenter.playCommand addTarget:self action:@selector(play)];
-    [commandCenter.pauseCommand addTarget:self action:@selector(pause)];
+    [commandCenter.togglePlayPauseCommand addTarget:self action:@selector(togglePlayPause)];
+    [commandCenter.playCommand addTarget:self action:@selector(togglePlayPause)];
+    [commandCenter.pauseCommand addTarget:self action:@selector(togglePlayPause)];
     [commandCenter.stopCommand addTarget:self action:@selector(stop)];
     [commandCenter.nextTrackCommand addTarget:self action:@selector(nextTrack)];
     [commandCenter.previousTrackCommand addTarget:self action:@selector(previousTrack)];
@@ -90,8 +91,6 @@ static MPRemoteCommandCenter *commandCenter = nil;
     commandCenter.likeCommand.isEnabled = false;
     commandCenter.dislikeCommand.isEnabled = false;
     commandCenter.bookmarkCommand.isEnabled = false;
-    // TODO: support toggling play/pause on the Flutter side?
-    commandCenter.togglePlayPauseCommand.isEnabled = false;
   } else if ([@"ready" isEqualToString:call.method]) {
     result(@YES);
     startResult(@YES);
@@ -193,11 +192,8 @@ static MPRemoteCommandCenter *commandCenter = nil;
     [backgroundChannel invokeMethod:call.method arguments:call.arguments result: result];
   }
 }
-- (void) play {
-  [backgroundChannel invokeMethod:@"onPlay" arguments:nil];
-}
-- (void) pause {
-  [backgroundChannel invokeMethod:@"onPause" arguments:nil];
+- (void) togglePlayPause {
+  [backgroundChannel invokeMethod:@"onTogglePlayPause" arguments:nil];
 }
 - (void) stop {
   [backgroundChannel invokeMethod:@"onStop" arguments:nil];

--- a/ios/Classes/AudioServicePlugin.m
+++ b/ios/Classes/AudioServicePlugin.m
@@ -92,31 +92,31 @@ static MPRemoteCommandCenter *commandCenter = nil;
   } else if ([@"setBrowseMediaParent" isEqualToString:call.method]) {
     result(@YES);
   } else if ([@"addQueueItem" isEqualToString:call.method]) {
-    [channel invokeMethod:@"onAddQueueItem" arguments:call.arguments];
+    [backgroundChannel invokeMethod:@"onAddQueueItem" arguments:call.arguments];
     result(@YES);
   } else if ([@"addQueueItemAt" isEqualToString:call.method]) {
-    [channel invokeMethod:@"onAddQueueItemAt" arguments:call.arguments];
+    [backgroundChannel invokeMethod:@"onAddQueueItemAt" arguments:call.arguments];
     result(@YES);
   } else if ([@"removeQueueItem" isEqualToString:call.method]) {
-    [channel invokeMethod:@"onRemoveQueueItem" arguments:call.arguments];
+    [backgroundChannel invokeMethod:@"onRemoveQueueItem" arguments:call.arguments];
     result(@YES);
   } else if ([@"click" isEqualToString:call.method]) {
-    [channel invokeMethod:@"onClick" arguments:call.arguments];
+    [backgroundChannel invokeMethod:@"onClick" arguments:call.arguments];
     result(@YES);
   } else if ([@"prepare" isEqualToString:call.method]) {
-    [channel invokeMethod:@"onPrepare" arguments:nil];
+    [backgroundChannel invokeMethod:@"onPrepare" arguments:nil];
     result(@YES);
   } else if ([@"prepareFromMediaId" isEqualToString:call.method]) {
-    [channel invokeMethod:@"onPrepareFromMediaId" arguments:call.arguments];
+    [backgroundChannel invokeMethod:@"onPrepareFromMediaId" arguments:call.arguments];
     result(@YES);
   } else if ([@"play" isEqualToString:call.method]) {
     [backgroundChannel invokeMethod:@"onPlay" arguments:nil];
     result(@YES);
   } else if ([@"playFromMediaId" isEqualToString:call.method]) {
-    [channel invokeMethod:@"onPlayFromMediaId" arguments:call.arguments];
+    [backgroundChannel invokeMethod:@"onPlayFromMediaId" arguments:call.arguments];
     result(@YES);
   } else if ([@"skipToQueueItem" isEqualToString:call.method]) {
-    [channel invokeMethod:@"onSkipToQueueItem" arguments:call.arguments];
+    [backgroundChannel invokeMethod:@"onSkipToQueueItem" arguments:call.arguments];
     result(@YES);
   } else if ([@"pause" isEqualToString:call.method]) {
     [backgroundChannel invokeMethod:@"onPause" arguments:nil];
@@ -125,22 +125,22 @@ static MPRemoteCommandCenter *commandCenter = nil;
     [backgroundChannel invokeMethod:@"onStop" arguments:nil];
     result(@YES);
   } else if ([@"seekTo" isEqualToString:call.method]) {
-    [channel invokeMethod:@"onSeekTo" arguments:call.arguments];
+    [backgroundChannel invokeMethod:@"onSeekTo" arguments:call.arguments];
     result(@YES);
   } else if ([@"skipToNext" isEqualToString:call.method]) {
-    [channel invokeMethod:@"onSkipToNext" arguments:nil];
+    [backgroundChannel invokeMethod:@"onSkipToNext" arguments:nil];
     result(@YES);
   } else if ([@"skipToPrevious" isEqualToString:call.method]) {
-    [channel invokeMethod:@"onSkipToPrevious" arguments:nil];
+    [backgroundChannel invokeMethod:@"onSkipToPrevious" arguments:nil];
     result(@YES);
   } else if ([@"fastForward" isEqualToString:call.method]) {
-    [channel invokeMethod:@"onFastForward" arguments:nil];
+    [backgroundChannel invokeMethod:@"onFastForward" arguments:nil];
     result(@YES);
   } else if ([@"rewind" isEqualToString:call.method]) {
-    [channel invokeMethod:@"onRewind" arguments:nil];
+    [backgroundChannel invokeMethod:@"onRewind" arguments:nil];
     result(@YES);
   } else if ([@"setRating" isEqualToString:call.method]) {
-    [channel invokeMethod:@"onSetRating" arguments:call.arguments];
+    [backgroundChannel invokeMethod:@"onSetRating" arguments:call.arguments];
     result(@YES);
   } else if ([@"setState" isEqualToString:call.method]) {
     [channel invokeMethod:@"onPlaybackStateChanged" arguments:@[
@@ -175,22 +175,22 @@ static MPRemoteCommandCenter *commandCenter = nil;
   }
 }
 - (void) play {
-  [channel invokeMethod:@"onPlay" arguments:nil];
+  [backgroundChannel invokeMethod:@"onPlay" arguments:nil];
 }
 - (void) pause {
-  [channel invokeMethod:@"onPause" arguments:nil];
+  [backgroundChannel invokeMethod:@"onPause" arguments:nil];
 }
 - (void) stop {
-  [channel invokeMethod:@"onStop" arguments:nil];
+  [backgroundChannel invokeMethod:@"onStop" arguments:nil];
 }
 - (void) nextTrack {
-  [channel invokeMethod:@"onSkipToNext" arguments:nil];
+  [backgroundChannel invokeMethod:@"onSkipToNext" arguments:nil];
 }
 - (void) previousTrack {
-  [channel invokeMethod:@"onSkipToPrevious" arguments:nil];
+  [backgroundChannel invokeMethod:@"onSkipToPrevious" arguments:nil];
 }
 - (void) changePlaybackPosition: (MPChangePlaybackPositionCommandEvent) event {
-  [channel invokeMethod:@"onSeekTo" arguments: @[event.positionTime]];
+  [backgroundChannel invokeMethod:@"onSeekTo" arguments: @[event.positionTime]];
 }
 
 @end

--- a/ios/Classes/AudioServicePlugin.m
+++ b/ios/Classes/AudioServicePlugin.m
@@ -92,11 +92,10 @@ static MPRemoteCommandCenter *commandCenter = nil;
   } else if ([@"setBrowseMediaParent" isEqualToString:call.method]) {
     result(@YES);
   } else if ([@"addQueueItem" isEqualToString:call.method]) {
-    [channel invokeMethod:@"addQueueItem" arguments:call.arguments];
+    [channel invokeMethod:@"onAddQueueItem" arguments:call.arguments];
     result(@YES);
   } else if ([@"addQueueItemAt" isEqualToString:call.method]) {
-      [channel invokeMethod:@"addQueueItemAt" arguments:call.arguments];
-
+    [channel invokeMethod:@"onAddQueueItemAt" arguments:call.arguments];
     result(@YES);
   } else if ([@"removeQueueItem" isEqualToString:call.method]) {
     [channel invokeMethod:@"onRemoveQueueItem" arguments:call.arguments];

--- a/ios/Classes/AudioServicePlugin.m
+++ b/ios/Classes/AudioServicePlugin.m
@@ -92,31 +92,32 @@ static MPRemoteCommandCenter *commandCenter = nil;
   } else if ([@"setBrowseMediaParent" isEqualToString:call.method]) {
     result(@YES);
   } else if ([@"addQueueItem" isEqualToString:call.method]) {
-    // TODO: pass through to onAddQueueItem
+    [channel invokeMethod:@"addQueueItem" arguments:call.arguments];
     result(@YES);
   } else if ([@"addQueueItemAt" isEqualToString:call.method]) {
-    // TODO: pass through to onAddQueueItemAt
+      [channel invokeMethod:@"addQueueItemAt" arguments:call.arguments];
+
     result(@YES);
   } else if ([@"removeQueueItem" isEqualToString:call.method]) {
-    // TODO: pass through to onRemoveQueueItem
+    [channel invokeMethod:@"onRemoveQueueItem" arguments:call.arguments];
     result(@YES);
   } else if ([@"click" isEqualToString:call.method]) {
-    // TODO: pass through to onClick
+    [channel invokeMethod:@"onClick" arguments:call.arguments];
     result(@YES);
   } else if ([@"prepare" isEqualToString:call.method]) {
-    // TODO: pass through to onPrepare
+    [channel invokeMethod:@"onPrepare" arguments:nil];
     result(@YES);
   } else if ([@"prepareFromMediaId" isEqualToString:call.method]) {
-    // TODO: pass through to onPrepareFromMediaId
+    [channel invokeMethod:@"onPrepareFromMediaId" arguments:call.arguments];
     result(@YES);
   } else if ([@"play" isEqualToString:call.method]) {
     [backgroundChannel invokeMethod:@"onPlay" arguments:nil];
     result(@YES);
   } else if ([@"playFromMediaId" isEqualToString:call.method]) {
-    // TODO: pass through to onPlayFromMediaId
+    [channel invokeMethod:@"onPlayFromMediaId" arguments:call.arguments];
     result(@YES);
   } else if ([@"skipToQueueItem" isEqualToString:call.method]) {
-    // TODO: pass through to onSkipToQueueItem
+    [channel invokeMethod:@"onSkipToQueueItem" arguments:call.arguments];
     result(@YES);
   } else if ([@"pause" isEqualToString:call.method]) {
     [backgroundChannel invokeMethod:@"onPause" arguments:nil];
@@ -125,22 +126,22 @@ static MPRemoteCommandCenter *commandCenter = nil;
     [backgroundChannel invokeMethod:@"onStop" arguments:nil];
     result(@YES);
   } else if ([@"seekTo" isEqualToString:call.method]) {
-    // TODO: pass through to onSeekTo
+    [channel invokeMethod:@"onSeekTo" arguments:call.arguments];
     result(@YES);
   } else if ([@"skipToNext" isEqualToString:call.method]) {
-    // TODO: pass through to onSkipToNext
+    [channel invokeMethod:@"onSkipToNext" arguments:nil];
     result(@YES);
   } else if ([@"skipToPrevious" isEqualToString:call.method]) {
-    // TODO: pass through to onSkipToPrevious
+    [channel invokeMethod:@"onSkipToPrevious" arguments:nil];
     result(@YES);
   } else if ([@"fastForward" isEqualToString:call.method]) {
-    // TODO: pass through to onFastForward
+    [channel invokeMethod:@"onFastForward" arguments:nil];
     result(@YES);
   } else if ([@"rewind" isEqualToString:call.method]) {
-    // TODO: pass through to onRewind
+    [channel invokeMethod:@"onRewind" arguments:nil];
     result(@YES);
   } else if ([@"setRating" isEqualToString:call.method]) {
-    // TODO: pass through to onRating
+    [channel invokeMethod:@"onSetRating" arguments:call.arguments];
     result(@YES);
   } else if ([@"setState" isEqualToString:call.method]) {
     [channel invokeMethod:@"onPlaybackStateChanged" arguments:@[

--- a/ios/Classes/AudioServicePlugin.m
+++ b/ios/Classes/AudioServicePlugin.m
@@ -71,7 +71,26 @@ static MPRemoteCommandCenter *commandCenter = nil;
     [commandCenter.nextTrackCommand addTarget:self action:@selector(nextTrack)];
     [commandCenter.previousTrackCommand addTarget:self action:@selector(previousTrack)];
     [commandCenter.changePlaybackPositionCommand addTarget:self action:@selector(changePlaybackPosition)];
-    // TODO - support toggling play/pause on the Flutter side?
+    // TODO: enable more commands
+    // Skipping
+    commandCenter.skipForwardCommand.isEnabled = false;
+    commandCenter.skipBackwardCommand.isEnabled = false;
+    // Seeking
+    commandCenter.seekForwardCommand.isEnabled = false;
+    commandCenter.seekBackwardCommand.isEnabled = false;
+    // Language options
+    commandCenter.enableLanguageOptionCommand.isEnabled = false;
+    commandCenter.disableLanguageOptionCommand.isEnabled = false;
+    // Repeat/Shuffle
+    commandCenter.changeRepeatModeCommand.isEnabled = false;
+    commandCenter.changeShuffleModeCommand.isEnabled = false;
+    // Rating
+    commandCenter.ratingCommand.isEnabled = false;
+    // Feedback
+    commandCenter.likeCommand.isEnabled = false;
+    commandCenter.dislikeCommand.isEnabled = false;
+    commandCenter.bookmarkCommand.isEnabled = false;
+    // TODO: support toggling play/pause on the Flutter side?
     commandCenter.togglePlayPauseCommand.isEnabled = false;
   } else if ([@"ready" isEqualToString:call.method]) {
     result(@YES);

--- a/lib/audio_service.dart
+++ b/lib/audio_service.dart
@@ -758,6 +758,9 @@ class AudioServiceBackground {
         case 'onSetRating':
           task.onSetRating(Rating._fromRaw(call.arguments[0]), call.arguments[1]);
           break;
+        case 'onTogglePlayPause':
+          task.onTogglePlayPause();
+          break;
         default:
           if (call.method.startsWith(_CUSTOM_PREFIX)) {
             task.onCustomAction(
@@ -953,6 +956,9 @@ abstract class BackgroundAudioTask {
   /// Called when the client has requested to rate the current media item, such as
   /// via a call to [AudioService.setRating].
   void onSetRating(Rating rating, Map<dynamic, dynamic> extras) {}
+
+  /// Called when the client has requested to toggle the current play state
+  void onTogglePlayPause() {}
 
   /// Called when a custom action has been sent by the client via
   /// [AudioService.customAction].


### PR DESCRIPTION
I've setup MPRemoteCommandCenter with callbacks. It seems we don't have a toggle method for handling the `togglePlayPauseCommand` defined on the Flutter side at the moment, so I've disabled it for now.

I've also passed through the simpler calls like 'rewind' -> 'onRewind'. It looks like the arguments are being encoded/decoded on the Flutter side so can simply be passed on without changing them... Right?