### PR TITLE
Add connected boolean

### DIFF
--- a/lib/audio_service.dart
+++ b/lib/audio_service.dart
@@ -431,6 +431,7 @@ class AudioService {
       }
     });
     await _channel.invokeMethod("connect");
+    _connected = true;
   }
 
   /// Disconnects your UI from the service.
@@ -439,7 +440,12 @@ class AudioService {
   static Future<void> disconnect() async {
     _channel.setMethodCallHandler(null);
     await _channel.invokeMethod("disconnect");
+    _connected = false;
   }
+
+  /// True if the UI is connected.
+  static bool get connected => _connected;
+  static bool _connected = false;
 
   /// True if the background audio task is running.
   static Future<bool> get running async {


### PR DESCRIPTION
This is for a pretty specific use case.

When I start the service, my app may already be connected, or it may not. I want to make sure it's connected to start the service, but then revert it to its previous state.

To do this, I need to check if it's already connected, with this new boolean, and if it isn't, I'll disconnect it after starting the service.