### PR TITLE
Fix background seek on iOS.

### DIFF
--- a/ios/Classes/AudioServicePlugin.m
+++ b/ios/Classes/AudioServicePlugin.m
@@ -335,7 +335,7 @@ static MPMediaItemArtwork* artwork = nil;
 
 - (MPRemoteCommandHandlerStatus) changePlaybackPosition: (MPChangePlaybackPositionCommandEvent *) event {
   NSLog(@"changePlaybackPosition");
-  [backgroundChannel invokeMethod:@"onSeekTo" arguments: @[@(event.positionTime)]];
+  [backgroundChannel invokeMethod:@"onSeekTo" arguments: @[@((long long) (event.positionTime * 1000))]];
   return MPRemoteCommandHandlerStatusSuccess;
 }
 


### PR DESCRIPTION
Fixed iOS background seek.
onSeekTo treat the position as 64-bit integer milliseconds.
However iOS code send it as TimeInterval(Double) seconds.