### PR TITLE
Account for playback speed in current position

### DIFF
--- a/lib/audio_service.dart
+++ b/lib/audio_service.dart
@@ -79,7 +79,10 @@ class PlaybackState {
   /// The current playback position in milliseconds
   int get currentPosition {
     if (basicState == BasicPlaybackState.playing) {
-      return position + DateTime.now().millisecondsSinceEpoch - updateTime;
+      return (position +
+              ((DateTime.now().millisecondsSinceEpoch - updateTime) *
+                  (speed ?? 1.0)))
+          .toInt();
     } else {
       return position;
     }
@@ -439,11 +442,15 @@ class AudioService {
           _playbackStateSubject.add(_playbackState);
           break;
         case 'onMediaChanged':
-          _currentMediaItem = call.arguments[0] != null ? _raw2mediaItem(call.arguments[0]) : null;
+          _currentMediaItem = call.arguments[0] != null
+              ? _raw2mediaItem(call.arguments[0])
+              : null;
           _currentMediaItemSubject.add(_currentMediaItem);
           break;
         case 'onQueueChanged':
-          final List<Map> args = call.arguments[0] != null ? List<Map>.from(call.arguments[0]) : null;
+          final List<Map> args = call.arguments[0] != null
+              ? List<Map>.from(call.arguments[0])
+              : null;
           _queue = args?.map(_raw2mediaItem)?.toList();
           _queueSubject.add(_queue);
           break;
@@ -865,7 +872,8 @@ class AudioServiceBackground {
               'action': control.action.index,
             })
         .toList();
-    final rawSystemActions = systemActions.map((action) => action.index).toList();
+    final rawSystemActions =
+        systemActions.map((action) => action.index).toList();
     await _backgroundChannel.invokeMethod('setState', [
       rawControls,
       rawSystemActions,


### PR DESCRIPTION
Noticed that the currentPosition getter doesn't account for playback at different speeds. This change should address that. Basically just multiplies the elapsed time by the playback speed and then calls `toInt()`.