### PR TITLE
Fix bug with FlutterIsolate

### DIFF
--- a/lib/audio_service.dart
+++ b/lib/audio_service.dart
@@ -372,6 +372,9 @@ class AudioService {
 
   static final _browseMediaChildrenSubject = BehaviorSubject<List<MediaItem>>();
 
+  /// An instance of flutter isolate
+  static FlutterIsolate _flutterIsolate;
+
   /// A stream that broadcasts the children of the current browse
   /// media parent.
   static Stream<List<MediaItem>> get browseMediaChildrenStream =>
@@ -531,7 +534,7 @@ class AudioService {
       // TODO: remove dependency on flutter_isolate by either using the
       // FlutterNativeView API directly or by waiting until Flutter allows
       // regular isolates to use method channels.
-      await FlutterIsolate.spawn(_iosIsolateEntrypoint, callbackHandle);
+      AudioService._flutterIsolate = await FlutterIsolate.spawn(_iosIsolateEntrypoint, callbackHandle);
     }
     return await _channel.invokeMethod('start', {
       'callbackHandle': callbackHandle,
@@ -816,7 +819,7 @@ class AudioServiceBackground {
     await task.onStart();
     await _backgroundChannel.invokeMethod('stopped');
     if (Platform.isIOS) {
-      FlutterIsolate.current.kill();
+      AudioService._flutterIsolate?.kill();
     }
     _backgroundChannel.setMethodCallHandler(null);
     _state = _noneState;


### PR DESCRIPTION
It is necessary to kill a specific FlutterIsolate instance, otherwise, if there are other FlutterIsolate instances in the project, then all of them will be killed when disposing of audio_service.