### PR TITLE
Stop audio_service from being restarted on kill

### DIFF
--- a/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -480,6 +480,7 @@ public class AudioService extends MediaBrowserServiceCompat implements AudioMana
 
 	@Override
 	public int onStartCommand(final Intent intent, int flags, int startId) {
+		if (intent == null) { stopSelf(); }
 		MediaButtonReceiver.handleIntent(mediaSession, intent);
 		return super.onStartCommand(intent, flags, startId);
 	}

--- a/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -480,9 +480,8 @@ public class AudioService extends MediaBrowserServiceCompat implements AudioMana
 
 	@Override
 	public int onStartCommand(final Intent intent, int flags, int startId) {
-		if (intent == null) { stopSelf(); }
 		MediaButtonReceiver.handleIntent(mediaSession, intent);
-		return super.onStartCommand(intent, flags, startId);
+		return START_NOT_STICKY;
 	}
 
 	@Override


### PR DESCRIPTION
This PR adds a check in onStartCommand to see if the intent equals null. If the intent is null the service is being restarted after being killed. This results in a stuck notification. My suggestion is calling stopSelf().

This is a solution to issue:
https://github.com/ryanheise/audio_service/issues/182