### PR TITLE
Support skip forward backward in command center (iOS).

### DIFF
--- a/ios/Classes/AudioServicePlugin.m
+++ b/ios/Classes/AudioServicePlugin.m
@@ -115,11 +115,13 @@ static MPMediaItemArtwork* artwork = nil;
     if (@available(iOS 9.1, *)) {
       [commandCenter.changePlaybackPositionCommand addTarget:self action:@selector(changePlaybackPosition:)];
     }
+    // Skipping
+    [commandCenter.skipForwardCommand setEnabled:YES];
+    [commandCenter.skipBackwardCommand setEnabled:YES];
+    [commandCenter.skipForwardCommand addTarget: self action:@selector(skipForward:)];
+    [commandCenter.skipBackwardCommand addTarget: self action:@selector(skipBackward:)];
 
     // TODO: enable more commands
-    // Skipping
-    [commandCenter.skipForwardCommand setEnabled:NO];
-    [commandCenter.skipBackwardCommand setEnabled:NO];
     // Seeking
     [commandCenter.seekForwardCommand setEnabled:NO];
     [commandCenter.seekBackwardCommand setEnabled:NO];
@@ -161,6 +163,11 @@ static MPMediaItemArtwork* artwork = nil;
     if (@available(iOS 9.1, *)) {
       [commandCenter.changePlaybackPositionCommand removeTarget:nil];
     }
+    // Skipping
+    [commandCenter.skipForwardCommand setEnabled:NO];
+    [commandCenter.skipBackwardCommand setEnabled:NO];
+    [commandCenter.skipForwardCommand removeTarget:nil];
+    [commandCenter.skipBackwardCommand removeTarget:nil];
     result(@YES);
   } else if ([@"isRunning" isEqualToString:call.method]) {
     if (_running) {
@@ -339,4 +346,15 @@ static MPMediaItemArtwork* artwork = nil;
   return MPRemoteCommandHandlerStatusSuccess;
 }
 
+- (MPRemoteCommandHandlerStatus) skipForward: (MPRemoteCommandEvent *) event {
+  NSLog(@"skipForward");
+  [backgroundChannel invokeMethod:@"onFastForward" arguments:nil];
+  return MPRemoteCommandHandlerStatusSuccess;
+}
+
+- (MPRemoteCommandHandlerStatus) skipBackward: (MPRemoteCommandEvent *) event {
+  NSLog(@"skipBackward");
+  [backgroundChannel invokeMethod:@"onRewind" arguments:nil];
+  return MPRemoteCommandHandlerStatusSuccess;
+}
 @end

--- a/ios/Classes/AudioServicePlugin.m
+++ b/ios/Classes/AudioServicePlugin.m
@@ -116,10 +116,18 @@ static MPMediaItemArtwork* artwork = nil;
       [commandCenter.changePlaybackPositionCommand addTarget:self action:@selector(changePlaybackPosition:)];
     }
     // Skipping
-    [commandCenter.skipForwardCommand setEnabled:YES];
-    [commandCenter.skipBackwardCommand setEnabled:YES];
-    [commandCenter.skipForwardCommand addTarget: self action:@selector(skipForward:)];
-    [commandCenter.skipBackwardCommand addTarget: self action:@selector(skipBackward:)];
+    NSNumber *skipForwardInterval = [call.arguments objectForKey:@"fastForwardInterval"];
+    NSNumber *skipBackwardInterval = [call.arguments objectForKey:@"rewindInterval"];
+    if (skipForwardInterval > 0) {
+      [commandCenter.skipForwardCommand setEnabled:YES];
+      [commandCenter.skipForwardCommand addTarget: self action:@selector(skipForward:)];
+      commandCenter.skipForwardCommand.preferredIntervals = @[skipForwardInterval];
+    }
+    if (skipBackwardInterval > 0) {
+      [commandCenter.skipBackwardCommand setEnabled:YES];
+      [commandCenter.skipBackwardCommand addTarget: self action:@selector(skipBackward:)];
+      commandCenter.skipBackwardCommand.preferredIntervals = @[skipBackwardInterval];
+    }
 
     // TODO: enable more commands
     // Seeking

--- a/lib/audio_service.dart
+++ b/lib/audio_service.dart
@@ -523,6 +523,8 @@ class AudioService {
     bool androidStopForegroundOnPause = false,
     bool enableQueue = false,
     bool androidStopOnRemoveTask = false,
+    int fastForwardInterval = 0,
+    int rewindInterval = 0,
   }) async {
     final ui.CallbackHandle handle =
         ui.PluginUtilities.getCallbackHandle(backgroundTaskEntrypoint);
@@ -558,6 +560,8 @@ class AudioService {
       'androidStopForegroundOnPause': androidStopForegroundOnPause,
       'enableQueue': enableQueue,
       'androidStopOnRemoveTask': androidStopOnRemoveTask,
+      'fastForwardInterval': fastForwardInterval,
+      'rewindInterval': rewindInterval,
     });
   }
 


### PR DESCRIPTION
This PR enables iOS skip forward and backward control in command center.

Because iOS's skip forward and backward buttons in command center need interval time (seconds) to display, add some start parameter.
If set zero or negative for the interval values, skip forward and/or backward buttons are disabled independently.