### PR TITLE
clearing PlayingInfoCenter's nowPlayingInfo on stopped

### DIFF
--- a/ios/Classes/AudioServicePlugin.m
+++ b/ios/Classes/AudioServicePlugin.m
@@ -161,6 +161,7 @@ static MPMediaItemArtwork* artwork = nil;
     if (@available(iOS 9.1, *)) {
       [commandCenter.changePlaybackPositionCommand removeTarget:nil];
     }
+    [MPNowPlayingInfoCenter defaultCenter].nowPlayingInfo = nil;
     result(@YES);
   } else if ([@"isRunning" isEqualToString:call.method]) {
     if (_running) {


### PR DESCRIPTION
After the player stops, the playing info remains in the command/control center and will cause issues if pressing play or possibly other buttons from within the control center. This clears the playing info and disables controls. 