### PR TITLE
Don't restart AudioService when it is killed

### DIFF
--- a/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -481,7 +481,7 @@ public class AudioService extends MediaBrowserServiceCompat implements AudioMana
 	@Override
 	public int onStartCommand(final Intent intent, int flags, int startId) {
 		MediaButtonReceiver.handleIntent(mediaSession, intent);
-		return super.onStartCommand(intent, flags, startId);
+		return START_NOT_STICKY;
 	}
 
 	@Override


### PR DESCRIPTION
Use START_NOT_STICKY so that the service isn't restated on kill.

Fixes issue: https://github.com/ryanheise/audio_service/issues/182