### PR TITLE
Fix default skip forward/backward controls in CommandCenter

### DIFF
--- a/ios/Classes/AudioServicePlugin.m
+++ b/ios/Classes/AudioServicePlugin.m
@@ -118,12 +118,12 @@ static MPMediaItemArtwork* artwork = nil;
     // Skipping
     NSNumber *skipForwardInterval = [call.arguments objectForKey:@"fastForwardInterval"];
     NSNumber *skipBackwardInterval = [call.arguments objectForKey:@"rewindInterval"];
-    if (skipForwardInterval > 0) {
+    if (skipForwardInterval.integerValue > 0) {
       [commandCenter.skipForwardCommand setEnabled:YES];
       [commandCenter.skipForwardCommand addTarget: self action:@selector(skipForward:)];
       commandCenter.skipForwardCommand.preferredIntervals = @[skipForwardInterval];
     }
-    if (skipBackwardInterval > 0) {
+    if (skipBackwardInterval.integerValue > 0) {
       [commandCenter.skipBackwardCommand setEnabled:YES];
       [commandCenter.skipBackwardCommand addTarget: self action:@selector(skipBackward:)];
       commandCenter.skipBackwardCommand.preferredIntervals = @[skipBackwardInterval];


### PR DESCRIPTION
Fixing an issue introduced with #196 

The control/command center always displays skip forward/backward controls now, by default.

`skipForwardInterval` and `skipBackwardInterval` are pointers to objects and therefore we need to access their `integerValue` property to have a valid comparison against 0.

Tested to work with and without passed in fastForwardInterval & rewindInterval values.