### PR TITLE
Add Artist to nowPlayingInfo

### DIFF
--- a/ios/Classes/AudioServicePlugin.m
+++ b/ios/Classes/AudioServicePlugin.m
@@ -314,6 +314,7 @@ static MPMediaItemArtwork* artwork = nil;
   if (mediaItem) {
     nowPlayingInfo[MPMediaItemPropertyTitle] = mediaItem[@"title"];
     nowPlayingInfo[MPMediaItemPropertyAlbumTitle] = mediaItem[@"album"];
+    nowPlayingInfo[MPMediaItemPropertyArtist] = mediaItem[@"artist"];
     if (mediaItem[@"duration"] != [NSNull null]) {
       nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = [NSNumber numberWithLongLong: ([mediaItem[@"duration"] longLongValue] / 1000)];
     }


### PR DESCRIPTION
Not Sure if this was missed or not implemented intentionally. However not having Artist doesn't show the full metadata in a vehicles head-unit. Additionally the Command Center was not showing the Artist name.

After adding this line of code that these problems are fixed.