### PR TITLE
Avoid unnecessary warning about null artist in media item on iOS.

### DIFF
--- a/ios/Classes/AudioServicePlugin.m
+++ b/ios/Classes/AudioServicePlugin.m
@@ -376,7 +376,9 @@ static MPMediaItemArtwork* artwork = nil;
   if (mediaItem) {
     nowPlayingInfo[MPMediaItemPropertyTitle] = mediaItem[@"title"];
     nowPlayingInfo[MPMediaItemPropertyAlbumTitle] = mediaItem[@"album"];
-    nowPlayingInfo[MPMediaItemPropertyArtist] = mediaItem[@"artist"];
+    if (mediaItem[@"artist"] != [NSNull null]) {
+      nowPlayingInfo[MPMediaItemPropertyArtist] = mediaItem[@"artist"];
+    }
     if (mediaItem[@"duration"] != [NSNull null]) {
       nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = [NSNumber numberWithLongLong: ([mediaItem[@"duration"] longLongValue] / 1000)];
     }


### PR DESCRIPTION
Log message on iOS when artist is not specified in MediaItem:

[MediaRemote] WARNING: Unexpected type for now playing key kMRMediaRemoteNowPlayingInfoArtist (is CFNull, should be CFString). Removing from now playing info dictionary.