### PR TITLE
use colon instead of comma on a Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ await AudioService.start(
   androidNotificationIcon: 'mipmap/ic_launcher',
   // An example of passing custom parameters.
   // These will be passed through to your `onStart` callback.
-  params: {'url', 'https://somewhere.com/sometrack.mp3'},
+  params: {'url': 'https://somewhere.com/sometrack.mp3'},
 );
 // this must be a top-level function
 void _myEntrypoint() => AudioServiceBackground.run(() => MyBackgroundTask());


### PR DESCRIPTION
In the section where AudioService is getting started (with `AudioService.start()`), the parameter named `params` expects a Map but there's a `Set` provided in the example. Maps are made up of key-value pairs and between the key and the value, a colon needs to be used. However on Sets, one needs to use comma to separate the elements of the Set.