### PR TITLE
Fixed bug, onClick method override not work.

### DIFF
--- a/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -598,12 +598,6 @@ public class AudioService extends MediaBrowserServiceCompat {
 				case KEYCODE_BYPASS_PAUSE:
 					onPause();
 					break;
-				case KeyEvent.KEYCODE_MEDIA_NEXT:
-					onSkipToNext();
-					break;
-				case KeyEvent.KEYCODE_MEDIA_PREVIOUS:
-					onSkipToPrevious();
-					break;
 				case KeyEvent.KEYCODE_MEDIA_STOP:
 					onStop();
 					break;
@@ -621,6 +615,8 @@ public class AudioService extends MediaBrowserServiceCompat {
 				// around this, we make PLAY and PAUSE actions use different keycodes:
 				// KEYCODE_BYPASS_PLAY/PAUSE. Now if we get KEYCODE_MEDIA_PLAY/PUASE
 				// we know it is actually a media button press.
+				case KeyEvent.KEYCODE_MEDIA_NEXT:
+				case KeyEvent.KEYCODE_MEDIA_PREVIOUS:
 				case KeyEvent.KEYCODE_MEDIA_PLAY:
 				case KeyEvent.KEYCODE_MEDIA_PAUSE:
 					// These are the "genuine" media button click events


### PR DESCRIPTION
Hi, Ryan.
I found that `onClick` method override not work when I tried to change actions for `MediaButton.next` and `MediaButton.previous` to `fastForward` and `rewind`. This are preferred actions for podcast playing.
```
  @override
  Future<void> onClick(MediaButton button) async {
    switch (button) {
      case MediaButton.media:
        if (AudioServiceBackground.state?.playing == true) {
          await onPause();
        } else {
          await onPlay();
        }
        break;
      case MediaButton.next:
        await onFastForward();
        break;
      case MediaButton.previous:
        await onRewind();
        break;
    }
  }
```
The PR changed the  `Event.KEYCODE_MEDIA_NEXT` and `KeyEvent.KEYCODE_MEDIA_PREVIOUS` to use `onClick` method on Android side to fix the issue.

Thanks for your great work as always!