### PR TITLE
Small bug fix for skipForward and backward.

### DIFF
--- a/ios/Classes/AudioServicePlugin.m
+++ b/ios/Classes/AudioServicePlugin.m
@@ -405,7 +405,9 @@ static MPMediaItemArtwork* artwork = nil;
             if (rewindInterval.integerValue > 0) {
                 if (enable) {
                     [commandCenter.skipBackwardCommand addTarget: self action:@selector(skipBackward:)];
-                    commandCenter.skipBackwardCommand.preferredIntervals = @[rewindInterval];
+                    int rewindIntervalInSeconds = (int) [rewindInterval floatValue]/1000;
+                    NSNumber *rewindIntervalInSec = [NSNumber numberWithInt: rewindIntervalInSeconds];
+                    commandCenter.skipBackwardCommand.preferredIntervals = @[rewindIntervalInSec];
                 } else {
                     [commandCenter.skipBackwardCommand removeTarget:nil];
                 }
@@ -429,7 +431,9 @@ static MPMediaItemArtwork* artwork = nil;
             if (fastForwardInterval.integerValue > 0) {
                 if (enable) {
                     [commandCenter.skipForwardCommand addTarget: self action:@selector(skipForward:)];
-                    commandCenter.skipForwardCommand.preferredIntervals = @[fastForwardInterval];
+                    int fastForwardIntervalInSeconds = (int) [fastForwardInterval floatValue]/1000;
+                    NSNumber *fastForwardIntervalInSec = [NSNumber numberWithInt: fastForwardIntervalInSeconds];
+                    commandCenter.skipForwardCommand.preferredIntervals = @[fastForwardIntervalInSec];
                 } else {
                     [commandCenter.skipForwardCommand removeTarget:nil];
                 }

--- a/ios/Classes/AudioServicePlugin.m
+++ b/ios/Classes/AudioServicePlugin.m
@@ -405,7 +405,7 @@ static MPMediaItemArtwork* artwork = nil;
             if (rewindInterval.integerValue > 0) {
                 if (enable) {
                     [commandCenter.skipBackwardCommand addTarget: self action:@selector(skipBackward:)];
-                    int rewindIntervalInSeconds = (int) [rewindInterval floatValue]/1000;
+                    int rewindIntervalInSeconds = [rewindInterval intValue]/1000;
                     NSNumber *rewindIntervalInSec = [NSNumber numberWithInt: rewindIntervalInSeconds];
                     commandCenter.skipBackwardCommand.preferredIntervals = @[rewindIntervalInSec];
                 } else {
@@ -431,7 +431,7 @@ static MPMediaItemArtwork* artwork = nil;
             if (fastForwardInterval.integerValue > 0) {
                 if (enable) {
                     [commandCenter.skipForwardCommand addTarget: self action:@selector(skipForward:)];
-                    int fastForwardIntervalInSeconds = (int) [fastForwardInterval floatValue]/1000;
+                    int fastForwardIntervalInSeconds = [fastForwardInterval intValue]/1000;
                     NSNumber *fastForwardIntervalInSec = [NSNumber numberWithInt: fastForwardIntervalInSeconds];
                     commandCenter.skipForwardCommand.preferredIntervals = @[fastForwardIntervalInSec];
                 } else {


### PR DESCRIPTION
On iOS commandCenter takes the interval in seconds whereas currently milliseconds were being passed. This caused the forward and rewind icons to show the wrong values. I fixed them.
Please take a look and let me know what you think.