### PR TITLE
Fix 8-bit boolean overflow when handling iOS actions

### DIFF
--- a/ios/Classes/AudioServicePlugin.m
+++ b/ios/Classes/AudioServicePlugin.m
@@ -376,7 +376,7 @@ static MPMediaItemArtwork* artwork = nil;
     MPRemoteCommand *command = commands[action];
     if (command == [NSNull null]) return;
     int actionBit = 1 << action;
-    BOOL enable = actionBits & actionBit;
+    BOOL enable = ((actionBits >> action) & 1);
     if (_controlsUpdated && enable == command.enabled) return;
     [command setEnabled:enable];
     switch (action) {

--- a/ios/Classes/AudioServicePlugin.m
+++ b/ios/Classes/AudioServicePlugin.m
@@ -375,7 +375,8 @@ static MPMediaItemArtwork* artwork = nil;
 - (void) updateControl:(enum MediaAction)action {
     MPRemoteCommand *command = commands[action];
     if (command == [NSNull null]) return;
-    int actionBit = 1 << action;
+    // Shift the actionBits right until the least significant bit is the tested action bit, and AND that with a 1 at the same position.
+    // All bytes become 0, other than the tested action bit, which will be 0 or 1 according to its status in the actionBits long.
     BOOL enable = ((actionBits >> action) & 1);
     if (_controlsUpdated && enable == command.enabled) return;
     [command setEnabled:enable];


### PR DESCRIPTION
Any enabled actions with an index equal to or higher than the `seekTo` enum's index don't get set correctly at the moment.

In Objective-C, BOOL variables are 8-bits long. As `seekTo` flips byte 9, this causes an overflow and sets the enable boolean in the current code to zero - resulting in seeking not getting enabled. Higher actions cause behaviour that's completely erratic.

This PR changes the bit shifting logic so the result is only a 0 or 1 for each tested flag.