### PR TITLE
Start receiving remote control events on iOS

### DIFF
--- a/darwin/Classes/AudioServicePlugin.m
+++ b/darwin/Classes/AudioServicePlugin.m
@@ -125,6 +125,8 @@ static MPMediaItemArtwork* artwork = nil;
 
 #if TARGET_OS_IPHONE
         [AVAudioSession sharedInstance];
+        // Start receiving remote control events if they have been stopped
+        [[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
 #endif
 
         // Set callbacks on MPRemoteCommandCenter


### PR DESCRIPTION
I'm not sure if this is relevant or just a edge case because of some other bad code, so feel free to close this if you think so.

I am using a custom video player that use the `MPRemoteCommandCenter`.  
On init it calls `beginReceivingRemoteControlEvents()` and `endReceivingRemoteControlEvents()` on deinit.

When audio_service starts should we make sure that we are receiving remote commands with
`[[UIApplication sharedApplication] beginReceivingRemoteControlEvents];` 
or should we assume that it's already enabled since it is default on?