### PR TITLE
Implementation of androidShowNotificationBadge.

### DIFF
--- a/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -62,6 +62,7 @@ public class AudioService extends MediaBrowserServiceCompat {
 	static String androidNotificationChannelDescription;
 	static Integer notificationColor;
 	static String androidNotificationIcon;
+	static boolean androidShowNotificationBadge;
 	static boolean androidNotificationClickStartsActivity;
 	static boolean androidNotificationOngoing;
 	static boolean androidStopForegroundOnPause;
@@ -77,7 +78,7 @@ public class AudioService extends MediaBrowserServiceCompat {
 	private static int shuffleMode;
 	private static boolean notificationCreated;
 
-	public static void init(Activity activity, boolean resumeOnClick, String androidNotificationChannelName, String androidNotificationChannelDescription, String action, Integer notificationColor, String androidNotificationIcon, boolean androidNotificationClickStartsActivity, boolean androidNotificationOngoing, boolean androidStopForegroundOnPause, Size artDownscaleSize, ServiceListener listener) {
+	public static void init(Activity activity, boolean resumeOnClick, String androidNotificationChannelName, String androidNotificationChannelDescription, String action, Integer notificationColor, String androidNotificationIcon, boolean androidShowNotificationBadge, boolean androidNotificationClickStartsActivity, boolean androidNotificationOngoing, boolean androidStopForegroundOnPause, Size artDownscaleSize, ServiceListener listener) {
 		if (running)
 			throw new IllegalStateException("AudioService already running");
 		running = true;
@@ -92,6 +93,7 @@ public class AudioService extends MediaBrowserServiceCompat {
 		AudioService.androidNotificationChannelDescription = androidNotificationChannelDescription;
 		AudioService.notificationColor = notificationColor;
 		AudioService.androidNotificationIcon = androidNotificationIcon;
+		AudioService.androidShowNotificationBadge = androidShowNotificationBadge;
 		AudioService.androidNotificationClickStartsActivity = androidNotificationClickStartsActivity;
 		AudioService.androidNotificationOngoing = androidNotificationOngoing;
 		AudioService.androidStopForegroundOnPause = androidStopForegroundOnPause;
@@ -330,6 +332,7 @@ public class AudioService extends MediaBrowserServiceCompat {
 		NotificationChannel channel = notificationManager.getNotificationChannel(notificationChannelId);
 		if (channel == null) {
 			channel = new NotificationChannel(notificationChannelId, androidNotificationChannelName, NotificationManager.IMPORTANCE_LOW);
+			channel.setShowBadge(androidShowNotificationBadge);
 			if (androidNotificationChannelDescription != null)
 				channel.setDescription(androidNotificationChannelDescription);
 			notificationManager.createNotificationChannel(channel);

--- a/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
+++ b/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
@@ -345,6 +345,7 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
 					String androidNotificationChannelDescription = (String)arguments.get("androidNotificationChannelDescription");
 					Integer androidNotificationColor = arguments.get("androidNotificationColor") == null ? null : getInt(arguments.get("androidNotificationColor"));
 					String androidNotificationIcon = (String)arguments.get("androidNotificationIcon");
+					boolean androidShowNotificationBadge = (Boolean)arguments.get("androidShowNotificationBadge");
 					final boolean androidEnableQueue = (Boolean)arguments.get("androidEnableQueue");
 					final boolean androidStopForegroundOnPause = (Boolean)arguments.get("androidStopForegroundOnPause");
 					final Map<String, Double> artDownscaleSizeMap = (Map)arguments.get("androidArtDownscaleSize");
@@ -355,7 +356,7 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
 
 					final String appBundlePath = FlutterMain.findAppBundlePath(context.getApplicationContext());
 					backgroundHandler = new BackgroundHandler(callbackHandle, appBundlePath, androidEnableQueue);
-					AudioService.init(activity, androidResumeOnClick, androidNotificationChannelName, androidNotificationChannelDescription, NOTIFICATION_CLICK_ACTION, androidNotificationColor, androidNotificationIcon, androidNotificationClickStartsActivity, androidNotificationOngoing, androidStopForegroundOnPause, artDownscaleSize, backgroundHandler);
+					AudioService.init(activity, androidResumeOnClick, androidNotificationChannelName, androidNotificationChannelDescription, NOTIFICATION_CLICK_ACTION, androidNotificationColor, androidNotificationIcon, androidShowNotificationBadge ,androidNotificationClickStartsActivity, androidNotificationOngoing, androidStopForegroundOnPause, artDownscaleSize, backgroundHandler);
 
 					synchronized (connectionCallback) {
 						if (mediaController != null)

--- a/lib/audio_service.dart
+++ b/lib/audio_service.dart
@@ -734,6 +734,9 @@ class AudioService {
   /// The [androidNotificationIcon] is specified like an XML resource reference
   /// and defaults to `"mipmap/ic_launcher"`.
   ///
+  /// [androidShowNotificationBadge] enable notification badges (also known as notification dots)
+  /// to appear on a launcher icon when the app has an active notification.
+  ///
   /// If specified, [androidArtDownscaleSize] causes artwork to be downscaled
   /// to the given resolution in pixels before being displayed in the
   /// notification and lock screen. If not specified, no downscaling will be
@@ -771,6 +774,7 @@ class AudioService {
     String androidNotificationChannelDescription,
     int androidNotificationColor,
     String androidNotificationIcon = 'mipmap/ic_launcher',
+    bool androidShowNotificationBadge = false,
     bool androidNotificationClickStartsActivity = true,
     bool androidNotificationOngoing = false,
     bool androidResumeOnClick = true,
@@ -817,6 +821,7 @@ class AudioService {
             androidNotificationChannelDescription,
         'androidNotificationColor': androidNotificationColor,
         'androidNotificationIcon': androidNotificationIcon,
+        'androidShowNotificationBadge': androidShowNotificationBadge,
         'androidNotificationClickStartsActivity':
             androidNotificationClickStartsActivity,
         'androidNotificationOngoing': androidNotificationOngoing,


### PR DESCRIPTION
Enable or disable notification badges (also known as notification dots) to appear on a launcher icon when the app has an active notification.