### PR TITLE
setSubText in android notification area.

### DIFF
--- a/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -280,8 +280,8 @@ public class AudioService extends MediaBrowserServiceCompat {
 				builder.setContentTitle(description.getTitle());
 			if (description.getSubtitle() != null)
 				builder.setContentText(description.getSubtitle());
-			if (description.getDescription() != null)
-				builder.setSubText(description.getDescription());
+			if (mediaMetadata.getString(MediaMetadataCompat.METADATA_KEY_DISPLAY_DESCRIPTION) != null)
+				builder.setSubText(mediaMetadata.getString(MediaMetadataCompat.METADATA_KEY_DISPLAY_DESCRIPTION));
 			if (description.getIconBitmap() != null)
 				builder.setLargeIcon(description.getIconBitmap());
 		}
@@ -721,7 +721,7 @@ public class AudioService extends MediaBrowserServiceCompat {
 			if (listener == null) return;
 			listener.onSetRating(rating);
 		}
-
+ 
 		@Override
 		public void onSetRepeatMode(int repeatMode) {
 			if (listener == null) return;


### PR DESCRIPTION
In the original code, even though there was an option to setSubText in android notification area, the getDescription() method always returned null. This is because the description was not set anywhere earlier in code and from what I checked, there was no easy way to do it. So I used displayDescription to set subtext in notification area.
Pls correct me if my understanding of anything is wrong.