### PR TITLE
Added onFirstConnect callback to AudioServiceWidget

### DIFF
--- a/lib/audio_service.dart
+++ b/lib/audio_service.dart
@@ -1849,10 +1849,14 @@ _iosIsolateEntrypoint(int rawHandle) async {
 ///
 /// Note that this widget will not work if it wraps around [MateriaApp] itself,
 /// you must place it in the widget tree within your route.
+/// 
+/// [onFirstConnect] callback will be executed if successfull connection to a 
+/// running service was made on first widget build.
 class AudioServiceWidget extends StatefulWidget {
   final Widget child;
+  final VoidCallback onFirstConnect;
 
-  AudioServiceWidget({@required this.child});
+  AudioServiceWidget({@required this.child, this.onFirstConnect});
 
   @override
   _AudioServiceWidgetState createState() => _AudioServiceWidgetState();
@@ -1864,7 +1868,11 @@ class _AudioServiceWidgetState extends State<AudioServiceWidget>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-    AudioService.connect();
+    AudioService.connect().then((_) {
+      if (widget.onFirstConnect != null && AudioService.running) {
+        widget.onFirstConnect();
+      }
+    });
   }
 
   @override


### PR DESCRIPTION
Was using my own version of AudioServiceWidget for a while and thought it might be useful for someone else. Although `runningStream` might be used for this as well. I personally send a `customAction` in this callback to obtain some UI info if service is already running when the app is opened.

Thanks again for this library, Ryan!