### PR TITLE
Implement per-MediaItem notification colors on Android

### DIFF
--- a/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -78,7 +78,7 @@ public class AudioService extends MediaBrowserServiceCompat {
 	private static int shuffleMode;
 	private static boolean notificationCreated;
 
-	public static void init(Activity activity, boolean resumeOnClick, String androidNotificationChannelName, String androidNotificationChannelDescription, String action, Integer notificationColor, String androidNotificationIcon, boolean androidShowNotificationBadge, boolean androidNotificationClickStartsActivity, boolean androidNotificationOngoing, boolean androidStopForegroundOnPause, Size artDownscaleSize, ServiceListener listener) {
+	public static void init(Activity activity, boolean resumeOnClick, String androidNotificationChannelName, String androidNotificationChannelDescription, String action, String androidNotificationIcon, boolean androidShowNotificationBadge, boolean androidNotificationClickStartsActivity, boolean androidNotificationOngoing, boolean androidStopForegroundOnPause, Size artDownscaleSize, ServiceListener listener) {
 		if (running)
 			throw new IllegalStateException("AudioService already running");
 		running = true;
@@ -91,7 +91,6 @@ public class AudioService extends MediaBrowserServiceCompat {
 		AudioService.resumeOnClick = resumeOnClick;
 		AudioService.androidNotificationChannelName = androidNotificationChannelName;
 		AudioService.androidNotificationChannelDescription = androidNotificationChannelDescription;
-		AudioService.notificationColor = notificationColor;
 		AudioService.androidNotificationIcon = androidNotificationIcon;
 		AudioService.androidShowNotificationBadge = androidShowNotificationBadge;
 		AudioService.androidNotificationClickStartsActivity = androidNotificationClickStartsActivity;
@@ -477,9 +476,10 @@ public class AudioService extends MediaBrowserServiceCompat {
 		mediaSessionCallback.onPlayMediaItem(description);
 	}
 
-	void setMetadata(final MediaMetadataCompat mediaMetadata) {
+	void setMetadata(final MediaMetadataCompat mediaMetadata, final Integer color) {
 		this.mediaMetadata = mediaMetadata;
 		mediaSession.setMetadata(mediaMetadata);
+		notificationColor = color;
 		updateNotification();
 	}
 

--- a/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
+++ b/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
@@ -343,7 +343,6 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
 					boolean androidResumeOnClick = (Boolean)arguments.get("androidResumeOnClick");
 					String androidNotificationChannelName = (String)arguments.get("androidNotificationChannelName");
 					String androidNotificationChannelDescription = (String)arguments.get("androidNotificationChannelDescription");
-					Integer androidNotificationColor = arguments.get("androidNotificationColor") == null ? null : getInt(arguments.get("androidNotificationColor"));
 					String androidNotificationIcon = (String)arguments.get("androidNotificationIcon");
 					boolean androidShowNotificationBadge = (Boolean)arguments.get("androidShowNotificationBadge");
 					final boolean androidEnableQueue = (Boolean)arguments.get("androidEnableQueue");
@@ -356,7 +355,7 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
 
 					final String appBundlePath = FlutterMain.findAppBundlePath(context.getApplicationContext());
 					backgroundHandler = new BackgroundHandler(callbackHandle, appBundlePath, androidEnableQueue);
-					AudioService.init(activity, androidResumeOnClick, androidNotificationChannelName, androidNotificationChannelDescription, NOTIFICATION_CLICK_ACTION, androidNotificationColor, androidNotificationIcon, androidShowNotificationBadge ,androidNotificationClickStartsActivity, androidNotificationOngoing, androidStopForegroundOnPause, artDownscaleSize, backgroundHandler);
+					AudioService.init(activity, androidResumeOnClick, androidNotificationChannelName, androidNotificationChannelDescription, NOTIFICATION_CLICK_ACTION, androidNotificationIcon, androidShowNotificationBadge ,androidNotificationClickStartsActivity, androidNotificationOngoing, androidStopForegroundOnPause, artDownscaleSize, backgroundHandler);
 
 					synchronized (connectionCallback) {
 						if (mediaController != null)
@@ -793,19 +792,21 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
 					AudioService.instance.notifyChildrenChanged(subscribedParentMediaId);
 				result.success(true);
 				break;
-			case "setMediaItem":
-				Map<?, ?> rawMediaItem = (Map<?, ?>)call.arguments;
+			case "setMediaItem": {
+				List<Object> args = (List<Object>)call.arguments;
+				Map<?, ?> rawMediaItem = (Map<?, ?>)args.get(0);
 				MediaMetadataCompat mediaMetadata = createMediaMetadata(rawMediaItem);
-				AudioService.instance.setMetadata(mediaMetadata);
+				AudioService.instance.setMetadata(mediaMetadata, getInt(args.get(1)));
 				result.success(true);
 				break;
+			}
 			case "setQueue":
 				List<Map<?, ?>> rawQueue = (List<Map<?, ?>>)call.arguments;
 				List<MediaSessionCompat.QueueItem> queue = raw2queue(rawQueue);
 				AudioService.instance.setQueue(queue);
 				result.success(true);
 				break;
-			case "setState":
+			case "setState": {
 				List<Object> args = (List<Object>)call.arguments;
 				List<Map<?, ?>> rawControls = (List<Map<?, ?>>)args.get(0);
 				List<Integer> rawSystemActions = (List<Integer>)args.get(1);
@@ -844,6 +845,7 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
 				AudioService.instance.setState(actions, actionBits, compactActionIndices, processingState, playing, position, bufferedPosition, speed, updateTimeSinceBoot, repeatMode, shuffleMode);
 				result.success(true);
 				break;
+			}
 			case "stopped":
 				clear();
 				result.success(true);

--- a/lib/audio_service.dart
+++ b/lib/audio_service.dart
@@ -772,7 +772,6 @@ class AudioService {
     Map<String, dynamic> params,
     String androidNotificationChannelName = "Notifications",
     String androidNotificationChannelDescription,
-    int androidNotificationColor,
     String androidNotificationIcon = 'mipmap/ic_launcher',
     bool androidShowNotificationBadge = false,
     bool androidNotificationClickStartsActivity = true,
@@ -819,7 +818,6 @@ class AudioService {
         'androidNotificationChannelName': androidNotificationChannelName,
         'androidNotificationChannelDescription':
             androidNotificationChannelDescription,
-        'androidNotificationColor': androidNotificationColor,
         'androidNotificationIcon': androidNotificationIcon,
         'androidShowNotificationBadge': androidShowNotificationBadge,
         'androidNotificationClickStartsActivity':
@@ -1486,7 +1484,11 @@ class AudioServiceBackground {
   }
 
   /// Sets the currently playing media item and notifies all clients.
-  static Future<void> setMediaItem(MediaItem mediaItem) async {
+  ///
+  /// [color] is the dominant color of the media item.
+  /// It is used in the service notification on supported platforms, and may be
+  /// left unset to let the system choose its own color.
+  static Future<void> setMediaItem(MediaItem mediaItem, [Color color]) async {
     _mediaItem = mediaItem;
     if (mediaItem.artUri != null) {
       // We potentially need to fetch the art.
@@ -1497,8 +1499,8 @@ class AudioServiceBackground {
         if (filePath == null) {
           // We haven't fetched the art yet, so show the metadata now, and again
           // after we load the art.
-          await _backgroundChannel.invokeMethod(
-              'setMediaItem', mediaItem.toJson());
+          await _backgroundChannel
+              .invokeMethod('setMediaItem', [mediaItem.toJson(), color?.value]);
           // Load the art
           filePath = await _loadArtwork(mediaItem);
           // If we failed to download the art, abort.
@@ -1512,9 +1514,10 @@ class AudioServiceBackground {
       final platformMediaItem = mediaItem.copyWith(extras: extras);
       // Show the media item after the art is loaded.
       await _backgroundChannel.invokeMethod(
-          'setMediaItem', platformMediaItem.toJson());
+          'setMediaItem', [platformMediaItem.toJson(), color?.value]);
     } else {
-      await _backgroundChannel.invokeMethod('setMediaItem', mediaItem.toJson());
+      await _backgroundChannel
+          .invokeMethod('setMediaItem', [mediaItem.toJson(), color?.value]);
     }
   }
 


### PR DESCRIPTION
As discussed in #520.
This PR is draft status, because:
1. Other platforms are broken, because the `setMediaItem` background channel call now passes a list with the media item JSON and the color integer (when it previously only passed the JSON).
2. The coloring doesn't work in newer versions of Android. Is this okay?
3. Scopes were added to two case statements in the method call switch in `AudioServicePlugin.java`, as a variable called `args` is now declared once in each. This makes the style inconsistent - should all cases have their own scope?