### PR TITLE
Specify the map type in MediaItem.copyWith's extras argument

### DIFF
--- a/lib/audio_service.dart
+++ b/lib/audio_service.dart
@@ -353,7 +353,7 @@ class MediaItem {
     String displaySubtitle,
     String displayDescription,
     Rating rating,
-    Map extras,
+    Map<String, dynamic> extras,
   }) =>
       MediaItem(
         id: id ?? this.id,


### PR DESCRIPTION
This fixes runtime errors when passing in map literals.