### PR TITLE
Allow a custom AudioHandler subtype to be used in init

### DIFF
--- a/lib/audio_service.dart
+++ b/lib/audio_service.dart
@@ -625,8 +625,8 @@ class AudioService {
   /// You may optionally specify a [cacheManager] to use when loading artwork to
   /// display in the media notification and lock screen. This defaults to
   /// [DefaultCacheManager].
-  static Future<AudioHandler> init({
-    @required AudioHandler builder(),
+  static Future<T> init<T extends AudioHandler>({
+    @required T builder(),
     AudioServiceConfig config,
     BaseCacheManager cacheManager,
   }) async {


### PR DESCRIPTION
This makes it easier to create the singleton with a specific type, useful for calling custom functions and using custom properties.