### PR TITLE
Make album metadata `Nullable` and remove empty string coercion to null from Android side

### DIFF
--- a/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -251,16 +251,14 @@ public class AudioService extends MediaBrowserServiceCompat {
 
     public int getPlaybackState() {
         switch (processingState) {
-        case none: return PlaybackStateCompat.STATE_NONE;
         case connecting: return PlaybackStateCompat.STATE_CONNECTING;
-        case ready: return playing ? PlaybackStateCompat.STATE_PLAYING : PlaybackStateCompat.STATE_PAUSED;
+        case ready: case completed: return playing ? PlaybackStateCompat.STATE_PLAYING : PlaybackStateCompat.STATE_PAUSED;
         case buffering: return PlaybackStateCompat.STATE_BUFFERING;
         case fastForwarding: return PlaybackStateCompat.STATE_FAST_FORWARDING;
         case rewinding: return PlaybackStateCompat.STATE_REWINDING;
         case skippingToPrevious: return PlaybackStateCompat.STATE_SKIPPING_TO_PREVIOUS;
         case skippingToNext: return PlaybackStateCompat.STATE_SKIPPING_TO_NEXT;
         case skippingToQueueItem: return PlaybackStateCompat.STATE_SKIPPING_TO_QUEUE_ITEM;
-        case completed: return playing ? PlaybackStateCompat.STATE_PLAYING : PlaybackStateCompat.STATE_PAUSED;
         case stopped: return PlaybackStateCompat.STATE_STOPPED;
         case error: return PlaybackStateCompat.STATE_ERROR;
         default: return PlaybackStateCompat.STATE_NONE;
@@ -385,10 +383,11 @@ public class AudioService extends MediaBrowserServiceCompat {
     static MediaMetadataCompat createMediaMetadata(String mediaId, String album, String title, String artist, String genre, Long duration, String artUri, Boolean playable, String displayTitle, String displaySubtitle, String displayDescription, RatingCompat rating, Map<?, ?> extras) {
         MediaMetadataCompat.Builder builder = new MediaMetadataCompat.Builder()
                 .putString(MediaMetadataCompat.METADATA_KEY_MEDIA_ID, mediaId)
-                .putString(MediaMetadataCompat.METADATA_KEY_ALBUM, album)
                 .putString(MediaMetadataCompat.METADATA_KEY_TITLE, title);
         if (artist != null)
             builder.putString(MediaMetadataCompat.METADATA_KEY_ARTIST, artist);
+        if (album != null)
+            builder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM, album);
         if (genre != null)
             builder.putString(MediaMetadataCompat.METADATA_KEY_GENRE, genre);
         if (duration != null)

--- a/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
+++ b/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
@@ -990,7 +990,8 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
         MediaDescriptionCompat description = mediaMetadata.getDescription();
         Map<String, Object> raw = new HashMap<String, Object>();
         raw.put("id", description.getMediaId());
-        raw.put("album", metadataToString(mediaMetadata, MediaMetadataCompat.METADATA_KEY_ALBUM));
+        if (mediaMetadata.containsKey(MediaMetadataCompat.METADATA_KEY_ALBUM))
+            raw.put("album", mediaMetadata.getString(MediaMetadataCompat.METADATA_KEY_ALBUM));
         raw.put("title", metadataToString(mediaMetadata, MediaMetadataCompat.METADATA_KEY_TITLE));
         if (description.getIconUri() != null)
             raw.put("artUri", description.getIconUri().toString());

--- a/darwin/Classes/AudioServicePlugin.m
+++ b/darwin/Classes/AudioServicePlugin.m
@@ -376,7 +376,9 @@ static MPMediaItemArtwork* artwork = nil;
     NSMutableDictionary *nowPlayingInfo = [NSMutableDictionary new];
     if (mediaItem) {
         nowPlayingInfo[MPMediaItemPropertyTitle] = mediaItem[@"title"];
-        nowPlayingInfo[MPMediaItemPropertyAlbumTitle] = mediaItem[@"album"];
+        if (mediaItem[@"album"] != [NSNull null]) {
+            nowPlayingInfo[MPMediaItemPropertyAlbumTitle] = mediaItem[@"album"];
+        }
         if (mediaItem[@"artist"] != [NSNull null]) {
             nowPlayingInfo[MPMediaItemPropertyArtist] = mediaItem[@"artist"];
         }

--- a/lib/audio_service.dart
+++ b/lib/audio_service.dart
@@ -260,11 +260,11 @@ class MediaItem {
   /// A unique id.
   final String id;
 
-  /// The album this media item belongs to.
-  final String album;
-
   /// The title of this media item.
   final String title;
+
+  /// The album this media item belongs to.
+  final String? album;
 
   /// The artist of this media item.
   final String? artist;
@@ -304,8 +304,8 @@ class MediaItem {
   /// each instance.
   const MediaItem({
     required this.id,
-    required this.album,
     required this.title,
+    this.album,
     this.artist,
     this.genre,
     this.duration,


### PR DESCRIPTION
This fixes issue [!621](https://github.com/ryanheise/audio_service/issues/621).

Some considerations:
- Having a required album metadata does not make sense for several media player scenarios since not all audio sessions can have an album.
- Looking at the documentation for [Android](https://developer.android.com/reference/kotlin/android/support/v4/media/MediaMetadataCompat) and [iOS](https://developer.apple.com/documentation/mediaplayer/mpmediaitempropertyalbumtitle), there is nothing that says we are required to define the album metadata in the media session.
- This was not a problem before null-safety support was added, because `MediaItem.album` would be `null` due to the coercion done by Android/Java native code and ignored by the `MediaItem` factory constructor. Currently it throws an Exception when instantiating `MediaItem` from raw data and therefore the new item is never broadcasted.

Tested on these real devices:
- Xiaomi Mi A3 Android 11
- iPhone 7 iOS 14.4

Reviewers:
@ryanheise 
