### PR TITLE
Start service as foreground

### DIFF
--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -521,7 +521,7 @@ public class AudioService extends MediaBrowserServiceCompat {
     }
 
     private boolean enterPlayingState() {
-        startService(new Intent(AudioService.this, AudioService.class));
+        startForegroundService(new Intent(AudioService.this, AudioService.class));
         if (!mediaSession.isActive())
             mediaSession.setActive(true);
 

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -31,6 +31,7 @@ import android.util.LruCache;
 import android.view.KeyEvent;
 
 import androidx.annotation.RequiresApi;
+import androidx.core.content.ContextCompat;
 import androidx.core.app.NotificationCompat;
 import androidx.media.MediaBrowserServiceCompat;
 import androidx.media.MediaBrowserServiceCompat.BrowserRoot;
@@ -521,7 +522,7 @@ public class AudioService extends MediaBrowserServiceCompat {
     }
 
     private boolean enterPlayingState() {
-        startForegroundService(new Intent(AudioService.this, AudioService.class));
+        ContextCompat.startForegroundService(this, new Intent(AudioService.this, AudioService.class));
         if (!mediaSession.isActive())
             mediaSession.setActive(true);
 


### PR DESCRIPTION
As discussed in #638, Android actually attempts to start the application in background via the `MediaButtonReceiver`. However, the system disallows the start of the service as there is no foreground activity.
In a simple implemetation this would cause the audio to start playing briefly (~5 sec according to SO) before the application is killed by the system, confusing the user.
This PR fixes the behavior by starting the service as a foreground service, which is allowed even if the application is not visible to the user (yet). Tested and working correctly on my device with my app.