### PR TITLE
Multiple services interface

### DIFF
--- a/audio_service/lib/audio_service.dart
+++ b/audio_service/lib/audio_service.dart
@@ -1028,11 +1028,11 @@ class AudioService {
             break;
           case 'subscribeToChildren':
             final parentMediaId = request.arguments![0] as String;
-            final sendPort = request.arguments![1] as SendPort?;
+            final sendPort = request.arguments![1] as SendPort;
             _handler
                 .subscribeToChildren(parentMediaId)
                 .listen((Map<String, dynamic>? options) {
-              sendPort!.send(options);
+              sendPort.send(options);
             });
             break;
           case 'getMediaItem':

--- a/audio_service/pubspec.yaml
+++ b/audio_service/pubspec.yaml
@@ -9,22 +9,22 @@ environment:
 
 dependencies:
   # Use these deps for local development
-  # audio_service_platform_interface:
-  #   path: ../audio_service_platform_interface
-  # audio_service_web:
-  #   path: ../audio_service_web
+  audio_service_platform_interface:
+    path: ../audio_service_platform_interface
+  audio_service_web:
+    path: ../audio_service_web
 
   # Use these deps when pushing to origin (for the benefit of testers)
-  audio_service_platform_interface:
-    git:
-      url: https://github.com/ryanheise/audio_service.git
-      ref: one-isolate
-      path: audio_service_platform_interface
-  audio_service_web:
-    git:
-      url: https://github.com/ryanheise/audio_service.git
-      ref: one-isolate
-      path: audio_service_web
+  # audio_service_platform_interface:
+  #   git:
+  #     url: https://github.com/ryanheise/audio_service.git
+  #     ref: one-isolate
+  #     path: audio_service_platform_interface
+  # audio_service_web:
+  #   git:
+  #     url: https://github.com/ryanheise/audio_service.git
+  #     ref: one-isolate
+  #     path: audio_service_web
 
   # Use these deps when publishing.
   # audio_service_platform_interface: ^1.0.0

--- a/audio_service_platform_interface/lib/audio_service_platform_interface.dart
+++ b/audio_service_platform_interface/lib/audio_service_platform_interface.dart
@@ -57,22 +57,18 @@ abstract class AudioServicePluginPlatform extends PlatformInterface {
   }
 }
 
-abstract class AudioServicePlatform
-    implements AudioServiceTwoSidePlatformCallbacks {
+abstract class AudioServicePlatform {
   final ComponentName name;
 
   const AudioServicePlatform({required this.name});
+
+  Future<void> setConfig(SetConfigRequest request);
 
   /// Set playback info on Android.
   Future<void> setAndroidPlaybackInfo(SetAndroidPlaybackInfoRequest request);
 
   /// Notify listeners that the children have changed.
   Future<void> notifyChildrenChanged(NotifyChildrenChangedRequest request);
-}
-
-/// Callbacks from that can be sent from both the platform and the dart code.
-abstract class AudioServiceTwoSidePlatformCallbacks {
-  const AudioServiceTwoSidePlatformCallbacks();
 
   /// Update playback state.
   Future<void> updatePlaybackState(UpdatePlaybackStateRequest request);
@@ -84,20 +80,16 @@ abstract class AudioServiceTwoSidePlatformCallbacks {
   Future<void> updateMediaItem(UpdateMediaItemRequest request);
 }
 
+/// Listens to events in platform code.
+// abstract class AudioServicePlatformListener {
+//   Future<void> onPlaybackStateChanged(UpdatePlaybackStateRequest request);
+//   Future<void> onQueueChanged(UpdateQueueRequest request);
+//   Future<void> onMediaItemChanged(UpdateMediaItemRequest request);
+//   // TODO: more callbacks
+// }
+
 /// Callbacks from the platform to the dart code.
-abstract class AudioServicePlatformCallbacks
-    implements AudioServiceTwoSidePlatformCallbacks {
-  const AudioServicePlatformCallbacks();
-
-  /// Get the children of a parent media item.
-  Future<GetChildrenResponse> getChildren(GetChildrenRequest request);
-
-  /// Get a particular media item.
-  Future<GetMediaItemResponse> getMediaItem(GetMediaItemRequest request);
-
-  /// Search for media items.
-  Future<SearchResponse> search(SearchRequest request);
-
+abstract class AudioServicePlatformCallbacks {
   /// Prepare media items for playback.
   Future<void> prepare(PrepareRequest request);
 
@@ -209,6 +201,15 @@ abstract class AudioServicePlatformCallbacks
   /// [setAndroidPlaybackInfo].
   Future<void> androidAdjustRemoteVolume(
       AndroidAdjustRemoteVolumeRequest request);
+
+  /// Get the children of a parent media item.
+  Future<GetChildrenResponse> getChildren(GetChildrenRequest request);
+
+  /// Get a particular media item.
+  Future<GetMediaItemResponse> getMediaItem(GetMediaItemRequest request);
+
+  /// Search for media items.
+  Future<SearchResponse> search(SearchRequest request);
 }
 
 abstract class AudioControllerPlatform {
@@ -798,17 +799,25 @@ class InitAudioControllerRequest {
 }
 
 class DisposeAudioServiceRequest {
-  @literal
-  const DisposeAudioServiceRequest();
+  final ComponentName name;
 
-  Map<String, dynamic> toMap() => <String, dynamic>{};
+  @literal
+  const DisposeAudioServiceRequest({required this.name});
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
+        'name': name.toMap(),
+      };
 }
 
 class DisposeAudioControllerRequest {
-  @literal
-  const DisposeAudioControllerRequest();
+  final ComponentName name;
 
-  Map<String, dynamic> toMap() => <String, dynamic>{};
+  @literal
+  const DisposeAudioControllerRequest({required this.name});
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
+        'name': name.toMap(),
+      };
 }
 
 class AndroidForceEnableMediaButtonsRequest {
@@ -816,6 +825,17 @@ class AndroidForceEnableMediaButtonsRequest {
   const AndroidForceEnableMediaButtonsRequest();
 
   Map<String, dynamic> toMap() => <String, dynamic>{};
+}
+
+class SetConfigRequest {
+  final AudioServiceConfigMessage config;
+
+  @literal
+  const SetConfigRequest({required this.config});
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
+        'config': config.toMap(),
+      };
 }
 
 class SetAndroidPlaybackInfoRequest {
@@ -896,76 +916,6 @@ class OnChildrenLoadedRequest {
                 MediaItemMessage.fromMap(_castMap(raw as Map)!))
             .toList(),
       );
-}
-
-class GetChildrenRequest {
-  final String parentMediaId;
-  final Map<String, dynamic>? options;
-
-  @literal
-  const GetChildrenRequest({required this.parentMediaId, this.options});
-
-  Map<String, dynamic> toMap() => <String, dynamic>{
-        'parentMediaId': parentMediaId,
-        'options': options,
-      };
-}
-
-class GetChildrenResponse {
-  final List<MediaItemMessage> children;
-
-  @literal
-  const GetChildrenResponse({required this.children});
-
-  Map<String, dynamic> toMap() => <String, dynamic>{
-        'children': children.map((item) => item.toMap()).toList(),
-      };
-}
-
-class GetMediaItemRequest {
-  final String mediaId;
-
-  @literal
-  const GetMediaItemRequest({required this.mediaId});
-
-  Map<String, dynamic> toMap() => <String, dynamic>{
-        'mediaId': mediaId,
-      };
-}
-
-class GetMediaItemResponse {
-  final MediaItemMessage? mediaItem;
-
-  @literal
-  const GetMediaItemResponse({required this.mediaItem});
-
-  Map<String, dynamic> toMap() => <String, dynamic>{
-        'mediaItem': mediaItem?.toMap(),
-      };
-}
-
-class SearchRequest {
-  final String query;
-  final Map<String, dynamic>? extras;
-
-  @literal
-  const SearchRequest({required this.query, this.extras});
-
-  Map<String, dynamic> toMap() => <String, dynamic>{
-        'query': query,
-        'extras': extras,
-      };
-}
-
-class SearchResponse {
-  final List<MediaItemMessage> mediaItems;
-
-  @literal
-  const SearchResponse({required this.mediaItems});
-
-  Map<String, dynamic> toMap() => <String, dynamic>{
-        'mediaItems': mediaItems.map((item) => item.toMap()).toList(),
-      };
 }
 
 class PrepareRequest {
@@ -1345,6 +1295,76 @@ class AndroidAdjustRemoteVolumeRequest {
       };
 }
 
+class GetChildrenRequest {
+  final String parentMediaId;
+  final Map<String, dynamic>? options;
+
+  @literal
+  const GetChildrenRequest({required this.parentMediaId, this.options});
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
+        'parentMediaId': parentMediaId,
+        'options': options,
+      };
+}
+
+class GetChildrenResponse {
+  final List<MediaItemMessage> children;
+
+  @literal
+  const GetChildrenResponse({required this.children});
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
+        'children': children.map((item) => item.toMap()).toList(),
+      };
+}
+
+class GetMediaItemRequest {
+  final String mediaId;
+
+  @literal
+  const GetMediaItemRequest({required this.mediaId});
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
+        'mediaId': mediaId,
+      };
+}
+
+class GetMediaItemResponse {
+  final MediaItemMessage? mediaItem;
+
+  @literal
+  const GetMediaItemResponse({required this.mediaItem});
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
+        'mediaItem': mediaItem?.toMap(),
+      };
+}
+
+class SearchRequest {
+  final String query;
+  final Map<String, dynamic>? extras;
+
+  @literal
+  const SearchRequest({required this.query, this.extras});
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
+        'query': query,
+        'extras': extras,
+      };
+}
+
+class SearchResponse {
+  final List<MediaItemMessage> mediaItems;
+
+  @literal
+  const SearchResponse({required this.mediaItems});
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
+        'mediaItems': mediaItems.map((item) => item.toMap()).toList(),
+      };
+}
+
 class ComponentName {
   final String package;
   final String className;
@@ -1361,6 +1381,17 @@ class ComponentName {
         'package': package,
         'className': className,
       };
+
+  @override
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType) return false;
+    return other is ComponentName &&
+        other.package == package &&
+        other.className == className;
+  }
+
+  @override
+  int get hashCode => hashValues(package, className);
 }
 
 /// The options to use when configuring the [AudioServicePlatform].

--- a/audio_service_platform_interface/lib/method_channel_audio_service.dart
+++ b/audio_service_platform_interface/lib/method_channel_audio_service.dart
@@ -1,243 +1,261 @@
 import 'package:flutter/services.dart';
 import 'audio_service_platform_interface.dart';
 
-class MethodChannelAudioService extends AudioServicePlatform {
-  final MethodChannel _channel =
-      MethodChannel('com.ryanheise.audio_service.methods');
+class MethodChannelAudioServicePlugin implements AudioServicePluginPlatform {
+  final MethodChannel _channel = MethodChannel('com.ryanheise.audio_service');
 
   @override
-  Future<ConfigureResponse> configure(ConfigureRequest request) async {
-    return ConfigureResponse.fromMap((await _channel
-        .invokeMapMethod<String, dynamic>('configure', request.toMap()))!);
+  Future<void> initService(InitAudioServiceRequest request) {
+    return _channel.invokeMethod<void>('initService', request.toMap());
   }
 
   @override
-  Future<void> updatePlaybackState(UpdatePlaybackStateRequest request) async {
-    await _channel.invokeMethod<void>('updatePlaybackState', request.toMap());
+  Future<void> initController(InitAudioControllerRequest request) {
+    return _channel.invokeMethod<void>('initController', request.toMap());
   }
 
   @override
-  Future<void> updateQueue(UpdateQueueRequest request) async {
-    await _channel.invokeMethod<void>('updateQueue', request.toMap());
+  Future<void> disposeService(DisposeAudioServiceRequest request) {
+    return _channel.invokeMethod<void>('disposeService', request.toMap());
   }
 
   @override
-  Future<void> updateMediaItem(UpdateMediaItemRequest request) async {
-    await _channel.invokeMethod<void>('updateMediaItem', request.toMap());
-  }
-
-  @override
-  Future<void> stopService(StopServiceRequest request) async {
-    await _channel.invokeMethod<void>('stopService', request.toMap());
-  }
-
-  @override
-  Future<void> setAndroidPlaybackInfo(
-      SetAndroidPlaybackInfoRequest request) async {
-    await _channel.invokeMethod<void>(
-        'setAndroidPlaybackInfo', request.toMap());
+  Future<void> disposeController(DisposeAudioControllerRequest request) {
+    return _channel.invokeMethod<void>('disposeController', request.toMap());
   }
 
   @override
   Future<void> androidForceEnableMediaButtons(
-      AndroidForceEnableMediaButtonsRequest request) async {
-    await _channel.invokeMethod<void>(
+      AndroidForceEnableMediaButtonsRequest request) {
+    return _channel.invokeMethod<void>(
+        'androidForceEnableMediaButtons', request.toMap());
+  }
+}
+
+class MethodChannelAudioService extends AudioServicePlatform {
+  final MethodChannel _channel;
+  final AudioServicePlatformCallbacks callbacks;
+
+  MethodChannelAudioService({
+    required ComponentName name,
+    required this.callbacks,
+  })  : _channel =
+            MethodChannel('com.ryanheise.audio_service.service.methods.$name'),
+        super(name: name) {
+    _channel.setMethodCallHandler(_handler);
+  }
+
+  @override
+  Future<void> setAndroidPlaybackInfo(SetAndroidPlaybackInfoRequest request) {
+    return _channel.invokeMethod<void>(
         'androidForceEnableMediaButtons', request.toMap());
   }
 
   @override
-  Future<void> notifyChildrenChanged(
-      NotifyChildrenChangedRequest request) async {
-    await _channel.invokeMethod<void>('notifyChildrenChanged', request.toMap());
+  Future<void> updatePlaybackState(UpdatePlaybackStateRequest request) {
+    return _channel.invokeMethod<void>('updatePlaybackState', request.toMap());
   }
 
   @override
-  void handlePlatformCall(AudioServicePlatformCallbacks callbacks) {
-    _channel.setMethodCallHandler((call) async {
-      switch (call.method) {
-        case 'updatePlaybackState':
-          await callbacks.updatePlaybackState(UpdatePlaybackStateRequest(
-              state: PlaybackStateMessage.fromMap(
-                  _castMap(call.arguments['state'] as Map)!)));
-          return null;
-        case 'updateQueue':
-          await callbacks.updateQueue(UpdateQueueRequest(
-              queue: call.arguments['queue'] == null
-                  ? []
-                  : (call.arguments['queue'] as List)
-                      .map((dynamic raw) =>
-                          MediaItemMessage.fromMap(_castMap(raw as Map)!))
-                      .toList()));
-          return null;
-        case 'updateMediaItem':
-          await callbacks.updateMediaItem(UpdateMediaItemRequest(
-              mediaItem: call.arguments['mediaItem'] == null
-                  ? null
-                  : MediaItemMessage.fromMap(
-                      _castMap(call.arguments['mediaItem'] as Map)!)));
-          return null;
-        case 'prepare':
-          await callbacks.prepare(const PrepareRequest());
-          return null;
-        case 'prepareFromMediaId':
-          await callbacks.prepareFromMediaId(PrepareFromMediaIdRequest(
-              mediaId: call.arguments['mediaId'] as String,
-              extras: _castMap(call.arguments['extras'] as Map?)));
-          return null;
-        case 'prepareFromSearch':
-          await callbacks.prepareFromSearch(PrepareFromSearchRequest(
-              query: call.arguments['query'] as String,
-              extras: _castMap(call.arguments['extras'] as Map?)));
-          return null;
-        case 'prepareFromUri':
-          await callbacks.prepareFromUri(PrepareFromUriRequest(
-              uri: Uri.parse(call.arguments['uri'] as String),
-              extras: _castMap(call.arguments['extras'] as Map?)));
-          return null;
-        case 'play':
-          await callbacks.play(const PlayRequest());
-          return null;
-        case 'playFromMediaId':
-          await callbacks.playFromMediaId(PlayFromMediaIdRequest(
-              mediaId: call.arguments['mediaId'] as String,
-              extras: _castMap(call.arguments['extras'] as Map?)));
-          return null;
-        case 'playFromSearch':
-          await callbacks.playFromSearch(PlayFromSearchRequest(
-              query: call.arguments['query'] as String,
-              extras: _castMap(call.arguments['extras'] as Map?)));
-          return null;
-        case 'playFromUri':
-          await callbacks.playFromUri(PlayFromUriRequest(
-              uri: Uri.parse(call.arguments['uri'] as String),
-              extras: _castMap(call.arguments['extras'] as Map?)));
-          return null;
-        case 'playMediaItem':
-          await callbacks.playMediaItem(PlayMediaItemRequest(
-              mediaItem: MediaItemMessage.fromMap(
-                  _castMap(call.arguments['mediaItem'] as Map)!)));
-          return null;
-        case 'pause':
-          await callbacks.pause(const PauseRequest());
-          return null;
-        case 'click':
-          await callbacks.click(ClickRequest(
-              button:
-                  MediaButtonMessage.values[call.arguments['button'] as int]));
-          return null;
-        case 'stop':
-          await callbacks.stop(const StopRequest());
-          return null;
-        case 'addQueueItem':
-          await callbacks.addQueueItem(AddQueueItemRequest(
-              mediaItem: MediaItemMessage.fromMap(
-                  _castMap(call.arguments['mediaItem'] as Map)!)));
-          return null;
-        case 'insertQueueItem':
-          await callbacks.insertQueueItem(InsertQueueItemRequest(
-              index: call.arguments['index'] as int,
-              mediaItem: MediaItemMessage.fromMap(
-                  _castMap(call.arguments['mediaItem'] as Map)!)));
-          return null;
-        case 'removeQueueItem':
-          await callbacks.removeQueueItem(RemoveQueueItemRequest(
-              mediaItem: MediaItemMessage.fromMap(
-                  _castMap(call.arguments['mediaItem'] as Map)!)));
-          return null;
-        case 'removeQueueItemAt':
-          await callbacks.removeQueueItemAt(
-              RemoveQueueItemAtRequest(index: call.arguments['index'] as int));
-          return null;
-        case 'skipToNext':
-          await callbacks.skipToNext(const SkipToNextRequest());
-          return null;
-        case 'skipToPrevious':
-          await callbacks.skipToPrevious(const SkipToPreviousRequest());
-          return null;
-        case 'fastForward':
-          await callbacks.fastForward(const FastForwardRequest());
-          return null;
-        case 'rewind':
-          await callbacks.rewind(const RewindRequest());
-          return null;
-        case 'skipToQueueItem':
-          await callbacks.skipToQueueItem(
-              SkipToQueueItemRequest(index: call.arguments['index'] as int));
-          return null;
-        case 'seekTo':
-          await callbacks.seek(SeekRequest(
-              position:
-                  Duration(microseconds: call.arguments['position'] as int)));
-          return null;
-        case 'setRepeatMode':
-          await callbacks.setRepeatMode(SetRepeatModeRequest(
-              repeatMode: AudioServiceRepeatModeMessage
-                  .values[call.arguments['repeatMode'] as int]));
-          return null;
-        case 'setShuffleMode':
-          await callbacks.setShuffleMode(SetShuffleModeRequest(
-              shuffleMode: AudioServiceShuffleModeMessage
-                  .values[call.arguments['shuffleMode'] as int]));
-          return null;
-        case 'setRating':
-          await callbacks.setRating(SetRatingRequest(
-              rating: RatingMessage.fromMap(
-                  _castMap(call.arguments['rating'] as Map)!),
-              extras: _castMap(call.arguments['extras'] as Map?)));
-          return null;
-        case 'setCaptioningEnabled':
-          await callbacks.setCaptioningEnabled(SetCaptioningEnabledRequest(
-              enabled: call.arguments['enabled'] as bool));
-          return null;
-        case 'seekBackward':
-          await callbacks.seekBackward(
-              SeekBackwardRequest(begin: call.arguments['begin'] as bool));
-          return null;
-        case 'seekForward':
-          await callbacks.seekForward(
-              SeekForwardRequest(begin: call.arguments['begin'] as bool));
-          return null;
-        case 'setSpeed':
-          await callbacks.setSpeed(
-              SetSpeedRequest(speed: call.arguments['speed'] as double));
-          return null;
-        case 'customAction':
-          await callbacks.customAction(CustomActionRequest(
-              name: call.arguments['name'] as String,
-              extras: _castMap(call.arguments['extras'] as Map?)));
-          return null;
-        case 'onTaskRemoved':
-          await callbacks.onTaskRemoved(const OnTaskRemovedRequest());
-          return null;
-        case 'onNotificationDeleted':
-          await callbacks
-              .onNotificationDeleted(const OnNotificationDeletedRequest());
-          return null;
-        case 'getChildren':
-          return (await callbacks.getChildren(GetChildrenRequest(
-                  parentMediaId: call.arguments['parentMediaId'] as String,
-                  options: _castMap(call.arguments['options'] as Map?))))
-              .toMap();
-        case 'getMediaItem':
-          return (await callbacks.getMediaItem(GetMediaItemRequest(
-              mediaId: call.arguments['mediaId'] as String)));
-        case 'search':
-          return (await callbacks
-              .search(SearchRequest(query: call.arguments['query'] as String)));
-        case 'setVolumeTo':
-          await callbacks.androidSetRemoteVolume(AndroidSetRemoteVolumeRequest(
-              volumeIndex: call.arguments['volumeIndex'] as int));
-          return null;
-        case 'adjustVolume':
-          await callbacks.androidAdjustRemoteVolume(
-              AndroidAdjustRemoteVolumeRequest(
-                  direction: AndroidVolumeDirectionMessage
-                      .values[call.arguments['direction']]!));
-          return null;
-        default:
-          throw PlatformException(code: 'Unimplemented');
-      }
-    });
+  Future<void> updateQueue(UpdateQueueRequest request) {
+    return _channel.invokeMethod<void>('updateQueue', request.toMap());
+  }
+
+  @override
+  Future<void> updateMediaItem(UpdateMediaItemRequest request) {
+    return _channel.invokeMethod<void>('updateMediaItem', request.toMap());
+  }
+
+  @override
+  Future<void> notifyChildrenChanged(NotifyChildrenChangedRequest request) {
+    return _channel.invokeMethod<void>(
+        'notifyChildrenChanged', request.toMap());
+  }
+
+  Future<dynamic> _handler(MethodCall call) async {
+    switch (call.method) {
+      case 'updatePlaybackState':
+        await callbacks.updatePlaybackState(UpdatePlaybackStateRequest(
+            state: PlaybackStateMessage.fromMap(
+                _castMap(call.arguments['state'] as Map)!)));
+        return null;
+      case 'updateQueue':
+        await callbacks.updateQueue(UpdateQueueRequest(
+            queue: call.arguments['queue'] == null
+                ? []
+                : (call.arguments['queue'] as List)
+                    .map((dynamic raw) =>
+                        MediaItemMessage.fromMap(_castMap(raw as Map)!))
+                    .toList()));
+        return null;
+      case 'updateMediaItem':
+        await callbacks.updateMediaItem(UpdateMediaItemRequest(
+            mediaItem: call.arguments['mediaItem'] == null
+                ? null
+                : MediaItemMessage.fromMap(
+                    _castMap(call.arguments['mediaItem'] as Map)!)));
+        return null;
+      case 'prepare':
+        await callbacks.prepare(const PrepareRequest());
+        return null;
+      case 'prepareFromMediaId':
+        await callbacks.prepareFromMediaId(PrepareFromMediaIdRequest(
+            mediaId: call.arguments['mediaId'] as String,
+            extras: _castMap(call.arguments['extras'] as Map?)));
+        return null;
+      case 'prepareFromSearch':
+        await callbacks.prepareFromSearch(PrepareFromSearchRequest(
+            query: call.arguments['query'] as String,
+            extras: _castMap(call.arguments['extras'] as Map?)));
+        return null;
+      case 'prepareFromUri':
+        await callbacks.prepareFromUri(PrepareFromUriRequest(
+            uri: Uri.parse(call.arguments['uri'] as String),
+            extras: _castMap(call.arguments['extras'] as Map?)));
+        return null;
+      case 'play':
+        await callbacks.play(const PlayRequest());
+        return null;
+      case 'playFromMediaId':
+        await callbacks.playFromMediaId(PlayFromMediaIdRequest(
+            mediaId: call.arguments['mediaId'] as String,
+            extras: _castMap(call.arguments['extras'] as Map?)));
+        return null;
+      case 'playFromSearch':
+        await callbacks.playFromSearch(PlayFromSearchRequest(
+            query: call.arguments['query'] as String,
+            extras: _castMap(call.arguments['extras'] as Map?)));
+        return null;
+      case 'playFromUri':
+        await callbacks.playFromUri(PlayFromUriRequest(
+            uri: Uri.parse(call.arguments['uri'] as String),
+            extras: _castMap(call.arguments['extras'] as Map?)));
+        return null;
+      case 'playMediaItem':
+        await callbacks.playMediaItem(PlayMediaItemRequest(
+            mediaItem: MediaItemMessage.fromMap(
+                _castMap(call.arguments['mediaItem'] as Map)!)));
+        return null;
+      case 'pause':
+        await callbacks.pause(const PauseRequest());
+        return null;
+      case 'click':
+        await callbacks.click(ClickRequest(
+            button:
+                MediaButtonMessage.values[call.arguments['button'] as int]));
+        return null;
+      case 'stop':
+        await callbacks.stop(const StopRequest());
+        return null;
+      case 'addQueueItem':
+        await callbacks.addQueueItem(AddQueueItemRequest(
+            mediaItem: MediaItemMessage.fromMap(
+                _castMap(call.arguments['mediaItem'] as Map)!)));
+        return null;
+      case 'insertQueueItem':
+        await callbacks.insertQueueItem(InsertQueueItemRequest(
+            index: call.arguments['index'] as int,
+            mediaItem: MediaItemMessage.fromMap(
+                _castMap(call.arguments['mediaItem'] as Map)!)));
+        return null;
+      case 'removeQueueItem':
+        await callbacks.removeQueueItem(RemoveQueueItemRequest(
+            mediaItem: MediaItemMessage.fromMap(
+                _castMap(call.arguments['mediaItem'] as Map)!)));
+        return null;
+      case 'removeQueueItemAt':
+        await callbacks.removeQueueItemAt(
+            RemoveQueueItemAtRequest(index: call.arguments['index'] as int));
+        return null;
+      case 'skipToNext':
+        await callbacks.skipToNext(const SkipToNextRequest());
+        return null;
+      case 'skipToPrevious':
+        await callbacks.skipToPrevious(const SkipToPreviousRequest());
+        return null;
+      case 'fastForward':
+        await callbacks.fastForward(const FastForwardRequest());
+        return null;
+      case 'rewind':
+        await callbacks.rewind(const RewindRequest());
+        return null;
+      case 'skipToQueueItem':
+        await callbacks.skipToQueueItem(
+            SkipToQueueItemRequest(index: call.arguments['index'] as int));
+        return null;
+      case 'seekTo':
+        await callbacks.seek(SeekRequest(
+            position:
+                Duration(microseconds: call.arguments['position'] as int)));
+        return null;
+      case 'setRepeatMode':
+        await callbacks.setRepeatMode(SetRepeatModeRequest(
+            repeatMode: AudioServiceRepeatModeMessage
+                .values[call.arguments['repeatMode'] as int]));
+        return null;
+      case 'setShuffleMode':
+        await callbacks.setShuffleMode(SetShuffleModeRequest(
+            shuffleMode: AudioServiceShuffleModeMessage
+                .values[call.arguments['shuffleMode'] as int]));
+        return null;
+      case 'setRating':
+        await callbacks.setRating(SetRatingRequest(
+            rating: RatingMessage.fromMap(
+                _castMap(call.arguments['rating'] as Map)!),
+            extras: _castMap(call.arguments['extras'] as Map?)));
+        return null;
+      case 'setCaptioningEnabled':
+        await callbacks.setCaptioningEnabled(SetCaptioningEnabledRequest(
+            enabled: call.arguments['enabled'] as bool));
+        return null;
+      case 'seekBackward':
+        await callbacks.seekBackward(
+            SeekBackwardRequest(begin: call.arguments['begin'] as bool));
+        return null;
+      case 'seekForward':
+        await callbacks.seekForward(
+            SeekForwardRequest(begin: call.arguments['begin'] as bool));
+        return null;
+      case 'setSpeed':
+        await callbacks.setSpeed(
+            SetSpeedRequest(speed: call.arguments['speed'] as double));
+        return null;
+      case 'customAction':
+        await callbacks.customAction(CustomActionRequest(
+            name: call.arguments['name'] as String,
+            extras: _castMap(call.arguments['extras'] as Map?)));
+        return null;
+      case 'onTaskRemoved':
+        await callbacks.onTaskRemoved(const OnTaskRemovedRequest());
+        return null;
+      case 'onNotificationDeleted':
+        await callbacks
+            .onNotificationDeleted(const OnNotificationDeletedRequest());
+        return null;
+      case 'getChildren':
+        return (await callbacks.getChildren(GetChildrenRequest(
+                parentMediaId: call.arguments['parentMediaId'] as String,
+                options: _castMap(call.arguments['options'] as Map?))))
+            .toMap();
+      case 'getMediaItem':
+        return (await callbacks.getMediaItem(
+            GetMediaItemRequest(mediaId: call.arguments['mediaId'] as String)));
+      case 'search':
+        return (await callbacks
+            .search(SearchRequest(query: call.arguments['query'] as String)));
+      case 'setVolumeTo':
+        await callbacks.androidSetRemoteVolume(AndroidSetRemoteVolumeRequest(
+            volumeIndex: call.arguments['volumeIndex'] as int));
+        return null;
+      case 'adjustVolume':
+        await callbacks.androidAdjustRemoteVolume(
+            AndroidAdjustRemoteVolumeRequest(
+                direction: AndroidVolumeDirectionMessage
+                    .values[call.arguments['direction']]!));
+        return null;
+      default:
+        throw PlatformException(code: 'Unimplemented');
+    }
   }
 }
 

--- a/audio_service_platform_interface/lib/method_channel_audio_service.dart
+++ b/audio_service_platform_interface/lib/method_channel_audio_service.dart
@@ -46,6 +46,11 @@ class MethodChannelAudioService extends AudioServicePlatform {
   }
 
   @override
+  Future<void> setConfig(SetConfigRequest request) {
+    return _channel.invokeMethod<void>('setConfig', request.toMap());
+  }
+
+  @override
   Future<void> setAndroidPlaybackInfo(SetAndroidPlaybackInfoRequest request) {
     return _channel.invokeMethod<void>(
         'androidForceEnableMediaButtons', request.toMap());
@@ -74,27 +79,27 @@ class MethodChannelAudioService extends AudioServicePlatform {
 
   Future<dynamic> _handler(MethodCall call) async {
     switch (call.method) {
-      case 'updatePlaybackState':
-        await callbacks.updatePlaybackState(UpdatePlaybackStateRequest(
-            state: PlaybackStateMessage.fromMap(
-                _castMap(call.arguments['state'] as Map)!)));
-        return null;
-      case 'updateQueue':
-        await callbacks.updateQueue(UpdateQueueRequest(
-            queue: call.arguments['queue'] == null
-                ? []
-                : (call.arguments['queue'] as List)
-                    .map((dynamic raw) =>
-                        MediaItemMessage.fromMap(_castMap(raw as Map)!))
-                    .toList()));
-        return null;
-      case 'updateMediaItem':
-        await callbacks.updateMediaItem(UpdateMediaItemRequest(
-            mediaItem: call.arguments['mediaItem'] == null
-                ? null
-                : MediaItemMessage.fromMap(
-                    _castMap(call.arguments['mediaItem'] as Map)!)));
-        return null;
+      // case 'onPlaybackStateChanged':
+      //   await listener?.onPlaybackStateChanged(UpdatePlaybackStateRequest(
+      //       state: PlaybackStateMessage.fromMap(
+      //           _castMap(call.arguments['state'] as Map)!)));
+      //   return null;
+      // case 'onQueueChanged':
+      //   await listener?.onQueueChanged(UpdateQueueRequest(
+      //       queue: call.arguments['queue'] == null
+      //           ? []
+      //           : (call.arguments['queue'] as List)
+      //               .map((dynamic raw) =>
+      //                   MediaItemMessage.fromMap(_castMap(raw as Map)!))
+      //               .toList()));
+      //   return null;
+      // case 'onMediaItemChanged':
+      //   await listener?.onMediaItemChanged(UpdateMediaItemRequest(
+      //       mediaItem: call.arguments['mediaItem'] == null
+      //           ? null
+      //           : MediaItemMessage.fromMap(
+      //               _castMap(call.arguments['mediaItem'] as Map)!)));
+      //   return null;
       case 'prepare':
         await callbacks.prepare(const PrepareRequest());
         return null;
@@ -232,6 +237,16 @@ class MethodChannelAudioService extends AudioServicePlatform {
         await callbacks
             .onNotificationDeleted(const OnNotificationDeletedRequest());
         return null;
+      case 'setVolumeTo':
+        await callbacks.androidSetRemoteVolume(AndroidSetRemoteVolumeRequest(
+            volumeIndex: call.arguments['volumeIndex'] as int));
+        return null;
+      case 'adjustVolume':
+        await callbacks.androidAdjustRemoteVolume(
+            AndroidAdjustRemoteVolumeRequest(
+                direction: AndroidVolumeDirectionMessage
+                    .values[call.arguments['direction']]!));
+        return null;
       case 'getChildren':
         return (await callbacks.getChildren(GetChildrenRequest(
                 parentMediaId: call.arguments['parentMediaId'] as String,
@@ -243,16 +258,6 @@ class MethodChannelAudioService extends AudioServicePlatform {
       case 'search':
         return (await callbacks
             .search(SearchRequest(query: call.arguments['query'] as String)));
-      case 'setVolumeTo':
-        await callbacks.androidSetRemoteVolume(AndroidSetRemoteVolumeRequest(
-            volumeIndex: call.arguments['volumeIndex'] as int));
-        return null;
-      case 'adjustVolume':
-        await callbacks.androidAdjustRemoteVolume(
-            AndroidAdjustRemoteVolumeRequest(
-                direction: AndroidVolumeDirectionMessage
-                    .values[call.arguments['direction']]!));
-        return null;
       default:
         throw PlatformException(code: 'Unimplemented');
     }

--- a/audio_service_platform_interface/lib/no_op_audio_service.dart
+++ b/audio_service_platform_interface/lib/no_op_audio_service.dart
@@ -1,22 +1,26 @@
 import 'audio_service_platform_interface.dart';
 
-class NoOpAudioService extends AudioServicePlatform {
+class NoOpAudioService implements AudioServicePlatform {
   @override
   Future<ConfigureResponse> configure(ConfigureRequest request) async {
     return ConfigureResponse();
   }
 
   @override
-  Future<void> setState(SetStateRequest request) async {}
+  Future<void> updatePlaybackState(UpdatePlaybackStateRequest request) async {}
 
   @override
-  Future<void> setQueue(SetQueueRequest request) async {}
+  Future<void> updateQueue(UpdateQueueRequest request) async {}
 
   @override
-  Future<void> setMediaItem(SetMediaItemRequest request) async {}
+  Future<void> updateMediaItem(UpdateMediaItemRequest request) async {}
 
   @override
   Future<void> stopService(StopServiceRequest request) async {}
+
+  @override
+  Future<void> setAndroidPlaybackInfo(
+      SetAndroidPlaybackInfoRequest request) async {}
 
   @override
   Future<void> androidForceEnableMediaButtons(
@@ -27,12 +31,5 @@ class NoOpAudioService extends AudioServicePlatform {
       NotifyChildrenChangedRequest request) async {}
 
   @override
-  Future<void> setAndroidPlaybackInfo(
-      SetAndroidPlaybackInfoRequest request) async {}
-
-  @override
-  void setClientCallbacks(AudioClientCallbacks callbacks) {}
-
-  @override
-  void setHandlerCallbacks(AudioHandlerCallbacks callbacks) {}
+  void handlePlatformCall(AudioServicePlatformCallbacks callbacks) {}
 }

--- a/audio_service_platform_interface/lib/no_op_audio_service.dart
+++ b/audio_service_platform_interface/lib/no_op_audio_service.dart
@@ -1,35 +1,31 @@
+import 'package:flutter/foundation.dart';
+
 import 'audio_service_platform_interface.dart';
 
-class NoOpAudioService implements AudioServicePlatform {
+class NoOpAudioServicePlugin extends AudioServicePluginPlatform {
   @override
-  Future<ConfigureResponse> configure(ConfigureRequest request) async {
-    return ConfigureResponse();
+  Future<void> initService(InitAudioServiceRequest request) {
+    return SynchronousFuture(null);
   }
 
   @override
-  Future<void> updatePlaybackState(UpdatePlaybackStateRequest request) async {}
+  Future<void> initController(InitAudioControllerRequest request) {
+    return SynchronousFuture(null);
+  }
 
   @override
-  Future<void> updateQueue(UpdateQueueRequest request) async {}
+  Future<void> disposeService(DisposeAudioServiceRequest request) {
+    return SynchronousFuture(null);
+  }
 
   @override
-  Future<void> updateMediaItem(UpdateMediaItemRequest request) async {}
-
-  @override
-  Future<void> stopService(StopServiceRequest request) async {}
-
-  @override
-  Future<void> setAndroidPlaybackInfo(
-      SetAndroidPlaybackInfoRequest request) async {}
+  Future<void> disposeController(DisposeAudioControllerRequest request) {
+    return SynchronousFuture(null);
+  }
 
   @override
   Future<void> androidForceEnableMediaButtons(
-      AndroidForceEnableMediaButtonsRequest request) async {}
-
-  @override
-  Future<void> notifyChildrenChanged(
-      NotifyChildrenChangedRequest request) async {}
-
-  @override
-  void handlePlatformCall(AudioServicePlatformCallbacks callbacks) {}
+      AndroidForceEnableMediaButtonsRequest request) {
+    return SynchronousFuture(null);
+  }
 }

--- a/audio_service_web/lib/audio_service_web.dart
+++ b/audio_service_web/lib/audio_service_web.dart
@@ -55,6 +55,11 @@ class AudioServiceWeb extends AudioServicePlatform {
   }) : super(name: name);
 
   @override
+  Future<void> setConfig(SetConfigRequest request) {
+    return SynchronousFuture(null);
+  }
+
+  @override
   Future<void> setAndroidPlaybackInfo(SetAndroidPlaybackInfoRequest request) {
     return SynchronousFuture(null);
   }
@@ -151,7 +156,7 @@ class AudioServiceWeb extends AudioServicePlatform {
 
           // Chrome looks for seconds for some reason
           setPositionState(PositionState(
-            duration: (mediaItem!.duration?.inMilliseconds ?? 0) / 1000,
+            duration: (mediaItem.duration?.inMilliseconds ?? 0) / 1000,
             playbackRate: request.state.speed,
             position: request.state.updatePosition.inMilliseconds / 1000,
           ));

--- a/audio_service_web/pubspec.yaml
+++ b/audio_service_web/pubspec.yaml
@@ -9,15 +9,15 @@ environment:
 
 dependencies:
   # Use these deps for local development
-  # audio_service_platform_interface:
-  #   path: ../audio_service_platform_interface
+  audio_service_platform_interface:
+    path: ../audio_service_platform_interface
 
   # Use these deps when pushing to origin (for the benefit of testers)
-  audio_service_platform_interface:
-    git:
-      url: https://github.com/ryanheise/audio_service.git
-      ref: one-isolate
-      path: audio_service_platform_interface
+  # audio_service_platform_interface:
+  #   git:
+  #     url: https://github.com/ryanheise/audio_service.git
+  #     ref: one-isolate
+  #     path: audio_service_platform_interface
 
   # Use these deps when publishing.
   # audio_service_platform_interface: ^1.0.0


### PR DESCRIPTION
To wrap up my plans:
* On Android multiple AudioServices can be spawned with ComponentName, eventually this will also allow connecting to other app's BrowserServices
* AudioService is inheritable on Android (I would imagine to do the same on other platforms, but this is not a priority)
* On Android stuff related to the BrowserRoot is going to the service, plugin then only spawns services and talks to engines
* On other platforms, only one service can be created, presumably with a default constructor, otherwise the exception will be thrown
* If isolates are supported, they still can connect to a service with creating an AudioService instance and then calling `connectFromIsolate()`