### PR TITLE
Fix engine disposal and service disconnect

### DIFF
--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
@@ -284,11 +284,6 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
         newIntentListener = null;
         clientInterface.setActivity(null);
         clientInterface.setContext(flutterPluginBinding.getApplicationContext());
-        if (clientInterfaces.size() == 1) {
-            // This unbinds from the service allowing AudioService.onDestroy to
-            // happen which in turn allows the FlutterEngine to be destroyed.
-            disconnect();
-        }
         if (clientInterface == mainClientInterface) {
             mainClientInterface = null;
         }
@@ -313,7 +308,7 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
         }
     }
 
-    private void disconnect() {
+    private static void disconnect() {
         Activity activity = mainClientInterface != null ? mainClientInterface.activity : null;
         if (activity != null) {
             // Since the activity enters paused state, we set the intent with ACTION_MAIN.
@@ -727,7 +722,10 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
 
         @Override
         public void onDestroy() {
-            disposeFlutterEngine();
+            if (clientInterfaces.size() == 1) {
+                disconnect();
+                disposeFlutterEngine();
+            }
         }
 
         @Override


### PR DESCRIPTION
Fixes https://github.com/ryanheise/audio_service/issues/671

What was happening:
1. You disconnected from the service when activity was destroyed. Service might be still running, but the media sources are no longer connected to the isolate, so external clients like Android Auto won't be able to reach the dart code. That is not really related to the #671, but just another issue I was aware of, but didn't file
2. The engine was destroyed unconditionally when service was killed, so at the time the new activity from (e.g. from quick actions) was attempted to be registered, it was registered to a dead engine, which caused a crash