### PR TITLE
Removal of unused interface

### DIFF
--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
@@ -102,50 +102,48 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
     private static MediaBrowserCompat mediaBrowser;
     private static MediaControllerCompat mediaController;
     private static final MediaControllerCompat.Callback controllerCallback = new MediaControllerCompat.Callback() {
-        @Override
-        public void onMetadataChanged(MediaMetadataCompat metadata) {
-            Map<String, Object> map = new HashMap<>();
-            map.put("mediaItem", mediaMetadata2raw(metadata));
-            invokeClientMethod("onMediaItemChanged", map);
-        }
-
-        @Override
-        public void onPlaybackStateChanged(PlaybackStateCompat state) {
-            // On the native side, we represent the update time relative to the boot time.
-            // On the flutter side, we represent the update time relative to the epoch.
-            long updateTimeSinceBoot = state.getLastPositionUpdateTime();
-            long updateTimeSinceEpoch = bootTime + updateTimeSinceBoot;
-            Map<String, Object> stateMap = new HashMap<>();
-            stateMap.put("processingState", AudioService.instance.getProcessingState().ordinal());
-            stateMap.put("playing", AudioService.instance.isPlaying());
-            stateMap.put("controls", new ArrayList<>());
-            long actionBits = state.getActions();
-            List<Object> systemActions = new ArrayList<>();
-            for (int actionIndex = 0; actionIndex < 64; actionIndex++) {
-                if ((actionBits & (1 << actionIndex)) != 0) {
-                    systemActions.add(actionIndex);
-                }
-            }
-            stateMap.put("systemActions", systemActions);
-            stateMap.put("updatePosition", state.getPosition());
-            stateMap.put("bufferedPosition", state.getBufferedPosition());
-            stateMap.put("speed", state.getPlaybackSpeed());
-            stateMap.put("updateTime", updateTimeSinceEpoch);
-            stateMap.put("repeatMode", AudioService.instance.getRepeatMode());
-            stateMap.put("shuffleMode", AudioService.instance.getShuffleMode());
-            Map<String, Object> map = new HashMap<>();
-            map.put("state", stateMap);
-            invokeClientMethod("onPlaybackStateChanged", map);
-        }
-
-        @Override
-        public void onQueueChanged(List<MediaSessionCompat.QueueItem> queue) {
-            Map<String, Object> map = new HashMap<>();
-            map.put("queue", queue2raw(queue));
-            invokeClientMethod("onQueueChanged", map);
-        }
-
-        // TODO: Add more callbacks.
+//        @Override
+//        public void onMetadataChanged(MediaMetadataCompat metadata) {
+//            Map<String, Object> map = new HashMap<>();
+//            map.put("mediaItem", mediaMetadata2raw(metadata));
+//            invokeClientMethod("onMediaItemChanged", map);
+//        }
+//
+//        @Override
+//        public void onPlaybackStateChanged(PlaybackStateCompat state) {
+//            // On the native side, we represent the update time relative to the boot time.
+//            // On the flutter side, we represent the update time relative to the epoch.
+//            long updateTimeSinceBoot = state.getLastPositionUpdateTime();
+//            long updateTimeSinceEpoch = bootTime + updateTimeSinceBoot;
+//            Map<String, Object> stateMap = new HashMap<>();
+//            stateMap.put("processingState", AudioService.instance.getProcessingState().ordinal());
+//            stateMap.put("playing", AudioService.instance.isPlaying());
+//            stateMap.put("controls", new ArrayList<>());
+//            long actionBits = state.getActions();
+//            List<Object> systemActions = new ArrayList<>();
+//            for (int actionIndex = 0; actionIndex < 64; actionIndex++) {
+//                if ((actionBits & (1 << actionIndex)) != 0) {
+//                    systemActions.add(actionIndex);
+//                }
+//            }
+//            stateMap.put("systemActions", systemActions);
+//            stateMap.put("updatePosition", state.getPosition());
+//            stateMap.put("bufferedPosition", state.getBufferedPosition());
+//            stateMap.put("speed", state.getPlaybackSpeed());
+//            stateMap.put("updateTime", updateTimeSinceEpoch);
+//            stateMap.put("repeatMode", AudioService.instance.getRepeatMode());
+//            stateMap.put("shuffleMode", AudioService.instance.getShuffleMode());
+//            Map<String, Object> map = new HashMap<>();
+//            map.put("state", stateMap);
+//            invokeClientMethod("onPlaybackStateChanged", map);
+//        }
+//
+//        @Override
+//        public void onQueueChanged(List<MediaSessionCompat.QueueItem> queue) {
+//            Map<String, Object> map = new HashMap<>();
+//            map.put("queue", queue2raw(queue));
+//            invokeClientMethod("onQueueChanged", map);
+//        }
     };
     private static final MediaBrowserCompat.ConnectionCallback connectionCallback = new MediaBrowserCompat.ConnectionCallback() {
         @Override

--- a/audio_service/lib/audio_service.dart
+++ b/audio_service/lib/audio_service.dart
@@ -2376,9 +2376,7 @@ class _IsolateAudioHandler extends AudioHandler {
   // ignore: close_sinks
   final BehaviorSubject<dynamic> customState = BehaviorSubject<dynamic>();
 
-  _IsolateAudioHandler() : super._() {
-    _platform.setClientCallbacks(_ClientCallbacks(this));
-  }
+  _IsolateAudioHandler() : super._();
 
   @override
   Future<void> prepare() => _send('prepare');
@@ -3629,14 +3627,6 @@ class _HandlerCallbacks extends AudioHandlerCallbacks {
   @override
   Future<void> stop(StopRequest request) => handler.stop();
 
-  @override
-  Future<void> updateMediaItem(UpdateMediaItemRequest request) =>
-      handler.updateMediaItem(request.mediaItem.toPlugin());
-
-  @override
-  Future<void> updateQueue(UpdateQueueRequest request) => handler
-      .updateQueue(request.queue.map((item) => item.toPlugin()).toList());
-
   final Map<String, ValueStream<Map<String, dynamic>?>> _childrenSubscriptions =
       {};
 
@@ -3656,48 +3646,6 @@ class _HandlerCallbacks extends AudioHandlerCallbacks {
     }
     return await handler.getChildren(parentMediaId, options);
   }
-}
-
-class _ClientCallbacks extends AudioClientCallbacks {
-  final _IsolateAudioHandler handler;
-
-  _ClientCallbacks(this.handler);
-
-  @override
-  Future<void> onMediaItemChanged(OnMediaItemChangedRequest request) async {
-    handler.mediaItem.add(request.mediaItem?.toPlugin());
-  }
-
-  @override
-  Future<void> onPlaybackStateChanged(
-      OnPlaybackStateChangedRequest request) async {
-    final state = request.state;
-    handler.playbackState.add(PlaybackState(
-      processingState: AudioProcessingState.values[state.processingState.index],
-      playing: state.playing,
-      // We can't determine whether they are controls.
-      systemActions: state.systemActions
-          .map((action) => MediaAction.values[action.index])
-          .toSet(),
-      updatePosition: state.updatePosition,
-      bufferedPosition: state.bufferedPosition,
-      speed: state.speed,
-      updateTime: state.updateTime,
-      repeatMode: AudioServiceRepeatMode.values[state.repeatMode.index],
-      shuffleMode: AudioServiceShuffleMode.values[state.shuffleMode.index],
-    ));
-  }
-
-  @override
-  Future<void> onQueueChanged(OnQueueChangedRequest request) async {
-    handler.queue.add(request.queue.map((item) => item.toPlugin()).toList());
-  }
-
-  //@override
-  //Future<void> onChildrenLoaded(OnChildrenLoadedRequest request) {
-  //  // TODO: implement onChildrenLoaded
-  //  throw UnimplementedError();
-  //}
 }
 
 /// Backwards compatible extensions on rxdart's ValueStream

--- a/audio_service_platform_interface/lib/method_channel_audio_service.dart
+++ b/audio_service_platform_interface/lib/method_channel_audio_service.dart
@@ -8,9 +8,8 @@ class MethodChannelAudioService extends AudioServicePlatform {
       const MethodChannel('com.ryanheise.audio_service.handler.methods');
 
   @override
-  Future<ConfigureResponse> configure(ConfigureRequest request) async {
-    return ConfigureResponse.fromMap((await _clientChannel
-        .invokeMapMethod<String, dynamic>('configure', request.toMap()))!);
+  Future<void> configure(ConfigureRequest request) async {
+    await _clientChannel.invokeMethod<void>('configure', request.toMap());
   }
 
   @override
@@ -52,34 +51,6 @@ class MethodChannelAudioService extends AudioServicePlatform {
       SetAndroidPlaybackInfoRequest request) async {
     await _handlerChannel.invokeMethod<void>(
         'setAndroidPlaybackInfo', request.toMap());
-  }
-
-  @override
-  void setClientCallbacks(AudioClientCallbacks callbacks) {
-    _clientChannel.setMethodCallHandler((call) async {
-      switch (call.method) {
-        case 'onPlaybackStateChanged':
-          callbacks.onPlaybackStateChanged(
-            OnPlaybackStateChangedRequest.fromMap(
-                _castMap(call.arguments as Map)!),
-          );
-          break;
-        case 'onMediaItemChanged':
-          callbacks.onMediaItemChanged(
-            OnMediaItemChangedRequest.fromMap(_castMap(call.arguments as Map)!),
-          );
-          break;
-        case 'onQueueChanged':
-          callbacks.onQueueChanged(
-            OnQueueChangedRequest.fromMap(_castMap(call.arguments as Map)!),
-          );
-          break;
-        //case 'onChildrenLoaded':
-        //  callbacks.onChildrenLoaded(
-        //      OnChildrenLoadedRequest.fromMap(call.arguments));
-        //  break;
-      }
-    });
   }
 
   @override
@@ -154,18 +125,6 @@ class MethodChannelAudioService extends AudioServicePlatform {
         case 'insertQueueItem':
           await callbacks.insertQueueItem(InsertQueueItemRequest(
               index: call.arguments['index'] as int,
-              mediaItem: MediaItemMessage.fromMap(
-                  _castMap(call.arguments['mediaItem'] as Map)!)));
-          return null;
-        case 'updateQueue':
-          await callbacks.updateQueue(UpdateQueueRequest(
-              queue: (call.arguments['queue'] as List)
-                  .map((dynamic raw) =>
-                      MediaItemMessage.fromMap(_castMap(raw as Map)!))
-                  .toList()));
-          return null;
-        case 'updateMediaItem':
-          await callbacks.updateMediaItem(UpdateMediaItemRequest(
               mediaItem: MediaItemMessage.fromMap(
                   _castMap(call.arguments['mediaItem'] as Map)!)));
           return null;

--- a/audio_service_platform_interface/lib/no_op_audio_service.dart
+++ b/audio_service_platform_interface/lib/no_op_audio_service.dart
@@ -2,9 +2,7 @@ import 'audio_service_platform_interface.dart';
 
 class NoOpAudioService extends AudioServicePlatform {
   @override
-  Future<ConfigureResponse> configure(ConfigureRequest request) async {
-    return ConfigureResponse();
-  }
+  Future<void> configure(ConfigureRequest request) async {}
 
   @override
   Future<void> setState(SetStateRequest request) async {}
@@ -29,9 +27,6 @@ class NoOpAudioService extends AudioServicePlatform {
   @override
   Future<void> setAndroidPlaybackInfo(
       SetAndroidPlaybackInfoRequest request) async {}
-
-  @override
-  void setClientCallbacks(AudioClientCallbacks callbacks) {}
 
   @override
   void setHandlerCallbacks(AudioHandlerCallbacks callbacks) {}

--- a/audio_service_web/lib/audio_service_web.dart
+++ b/audio_service_web/lib/audio_service_web.dart
@@ -15,10 +15,7 @@ class AudioServiceWeb extends AudioServicePlatform {
   MediaItemMessage? mediaItem;
 
   @override
-  Future<ConfigureResponse> configure(ConfigureRequest request) async {
-    return ConfigureResponse();
-    // throw UnimplementedError('configure() has not been implemented.');
-  }
+  Future<void> configure(ConfigureRequest request) async {}
 
   @override
   Future<void> setState(SetStateRequest request) async {
@@ -42,7 +39,8 @@ class AudioServiceWeb extends AudioServicePlatform {
           case MediaActionMessage.skipToPrevious:
             session.setActionHandler(
               'previoustrack',
-              () => handlerCallbacks?.skipToPrevious(const SkipToPreviousRequest()),
+              () => handlerCallbacks
+                  ?.skipToPrevious(const SkipToPreviousRequest()),
             );
             break;
           case MediaActionMessage.skipToNext:
@@ -152,13 +150,7 @@ class AudioServiceWeb extends AudioServicePlatform {
     final session = html.window.navigator.mediaSession!;
     session.metadata = null;
     mediaItem = null;
-
-    // Not sure if anything needs to happen here
-    // throw UnimplementedError('stopService() has not been implemented.');
   }
-
-  @override
-  void setClientCallbacks(AudioClientCallbacks callbacks) {}
 
   @override
   void setHandlerCallbacks(AudioHandlerCallbacks callbacks) {


### PR DESCRIPTION
* Removed `ConfigureResponse` (as discussed in https://github.com/ryanheise/audio_service/issues/415#issuecomment-859193526)
* Removed client session callbacks. In future we plan a slightly different API for these callbacks, currently they are not used (as discussed in https://github.com/ryanheise/audio_service/issues/415#issuecomment-859657864)
* Removed `updateQueue` and `updateMediaItem` as currently unused. This might be brought later when we reach `media2` (as discussed in https://github.com/ryanheise/audio_service/issues/415#issuecomment-859662895)

Didn't touch - `setSpeed` and `onNotificationClicked` as I plan to implement them