### PR TITLE
Fix for flutter Beta branch

### DIFF
--- a/lib/audio_service.dart
+++ b/lib/audio_service.dart
@@ -11,6 +11,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_isolate/flutter_isolate.dart';
 import 'package:rxdart/rxdart.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 /// Name of port used to send custom events.
 const _CUSTOM_EVENT_PORT_NAME = 'customEventPort';


### PR DESCRIPTION
On flutter beta branch during build package produce next error:     

- 'MethodChannel' is from 'package:flutter/src/services/platform_channel.dart' ('../../../flutter/packages/flutter/lib/src/services/platform_channel.dart').
    Try correcting the name to the name of an existing method, or defining a method named 'setMockMethodCallHandler'.
              .setMockMethodCallHandler(handler);
               ^^^^^^^^^^^^^^^^^^^^^^^^

The error happened because setMockMethodCallHandler method was moved to flutter_test package