### PR TITLE
update readme - add just_audio_handler

### DIFF
--- a/audio_service/README.md
+++ b/audio_service/README.md
@@ -41,7 +41,7 @@ Read the [Migration Guide](https://github.com/ryanheise/audio_service/wiki/Migra
 
 ## Can I make use of other plugins within the audio handler?
 
-Yes! `audio_service` is designed to let you implement the audio logic however you want, using whatever plugins you want. You can use your favourite audio plugins such as [just_audio](https://pub.dartlang.org/packages/just_audio), [flutter_radio](https://pub.dev/packages/flutter_radio), [flutter_tts](https://pub.dartlang.org/packages/flutter_tts), and others, within your background audio task.
+Yes! `audio_service` is designed to let you implement the audio logic however you want, using whatever plugins you want. You can use your favourite audio plugins such as [just_audio](https://pub.dartlang.org/packages/just_audio), [flutter_radio](https://pub.dev/packages/flutter_radio), [flutter_tts](https://pub.dartlang.org/packages/flutter_tts), and others, within your background audio task. There are also plugins like [just_audio_handlers](https://github.com/yringler/inside-app/tree/master/just_audio_handlers) that provide default implementations of `AudioHandler` to make your job easier.
 
 Note that this plugin will not work with other audio plugins that overlap in responsibility with this plugin (i.e. background audio, iOS control center, Android notifications, lock screen, headset buttons, etc.)
 


### PR DESCRIPTION
For a while I've noticed that people were coming over to just_audio_service, forking or leaving a star, and I was wondering how they came by? Until I noticed that you had kindly linked to it in the audio_service README. Which left me mildly horrified, because by this point (basically since dart when null safe) it was pretty dated (a fact which I made every effort to make clear in the README), but still it was nice.
And thank you for the plug in the audio_service changelog! It is admittedly a very niche wall of honor, but still very meaningful.

Back to business - this PR adds to the audio_service README (noting that my obsolete package was rightly removed) the new just_audio_handlers package. I'm not going to reiterate overmuch what I write in my [README](https://github.com/yringler/inside-app/blob/master/just_audio_handlers/README.md), but suffice to say it is much improved over my previous works.

Note that it is part of a monorepo, which also contains my app. That might make it mildly more inconvenient for other people, but it makes it massively simpler for myself, especially when it's under a lot of development. I'm open to breaking it out into its own repo if enough people are interested.

It is not in use in production quite yet, but will probably be in a public beta later this week. It's holding up well (after fixing the usual spate of bugs) in my local testing.