### PR TITLE
Move `mediaItem` and `queue` change to non-UI thread

### DIFF
--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -580,6 +580,10 @@ public class AudioService extends MediaBrowserServiceCompat {
         mediaSession = null;
     }
 
+    /**
+     * Updates queue.
+     * Gets called from background thread.
+     */
     synchronized void setQueue(List<MediaSessionCompat.QueueItem> queue) {
         this.queue = queue;
         mediaSession.setQueue(queue);
@@ -589,6 +593,10 @@ public class AudioService extends MediaBrowserServiceCompat {
         mediaSessionCallback.onPlayMediaItem(description);
     }
 
+    /**
+     * Updates metadata, loads the art and updates the notification.
+     * Gets called from background thread.
+     */
     synchronized void setMetadata(final MediaMetadataCompat mediaMetadata) {
         this.mediaMetadata = mediaMetadata;
         mediaSession.setMetadata(mediaMetadata);

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -580,7 +580,7 @@ public class AudioService extends MediaBrowserServiceCompat {
         mediaSession = null;
     }
 
-    void setQueue(List<MediaSessionCompat.QueueItem> queue) {
+    synchronized void setQueue(List<MediaSessionCompat.QueueItem> queue) {
         this.queue = queue;
         mediaSession.setQueue(queue);
     }

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
@@ -8,6 +8,8 @@ import android.media.AudioFormat;
 import android.media.AudioManager;
 import android.media.AudioTrack;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.SystemClock;
 
 import androidx.annotation.UiThread;
@@ -30,6 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Executors;
 
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -47,6 +50,7 @@ import io.flutter.embedding.engine.FlutterEngineCache;
 import io.flutter.embedding.engine.dart.DartExecutor;
 
 import android.net.Uri;
+import android.util.Log;
 
 /**
  * AudioservicePlugin
@@ -766,17 +770,35 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
             Map<?, ?> args = (Map<?, ?>)call.arguments;
             switch (call.method) {
             case "setMediaItem": {
-                Map<?, ?> rawMediaItem = (Map<?, ?>)args.get("mediaItem");
-                MediaMetadataCompat mediaMetadata = createMediaMetadata(rawMediaItem);
-                AudioService.instance.setMetadata(mediaMetadata);
-                result.success(null);
+                Handler handler = new Handler(Looper.getMainLooper());
+                Executors.newSingleThreadExecutor().execute(() -> {
+                    try {
+                        Map<?, ?> rawMediaItem = (Map<?, ?>)args.get("mediaItem");
+                        MediaMetadataCompat mediaMetadata = createMediaMetadata(rawMediaItem);
+                        AudioService.instance.setMetadata(mediaMetadata);
+                        handler.post(() -> result.success(null));
+                    } catch (Exception e) {
+                        handler.post(() -> {
+                            result.error("UNEXPECTED_ERROR", "Unexpected error", Log.getStackTraceString(e));
+                        });
+                    }
+                });
                 break;
             }
             case "setQueue": {
-                @SuppressWarnings("unchecked") List<Map<?, ?>> rawQueue = (List<Map<?, ?>>)args.get("queue");
-                List<MediaSessionCompat.QueueItem> queue = raw2queue(rawQueue);
-                AudioService.instance.setQueue(queue);
-                result.success(null);
+                Handler handler = new Handler(Looper.getMainLooper());
+                Executors.newSingleThreadExecutor().execute(() -> {
+                     try {
+                         @SuppressWarnings("unchecked") List<Map<?, ?>> rawQueue = (List<Map<?, ?>>) args.get("queue");
+                         List<MediaSessionCompat.QueueItem> queue = raw2queue(rawQueue);
+                         AudioService.instance.setQueue(queue);
+                         handler.post(() -> result.success(null));
+                     } catch (Exception e) {
+                         handler.post(() -> {
+                             result.error("UNEXPECTED_ERROR", "Unexpected error", Log.getStackTraceString(e));
+                         });
+                     }
+                });
                 break;
             }
             case "setState": {

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
@@ -765,12 +765,13 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
             disposeFlutterEngine();
         }
 
+        Handler handler = new Handler(Looper.getMainLooper());
+
         @Override
         public void onMethodCall(MethodCall call, Result result) {
             Map<?, ?> args = (Map<?, ?>)call.arguments;
             switch (call.method) {
             case "setMediaItem": {
-                Handler handler = new Handler(Looper.getMainLooper());
                 Executors.newSingleThreadExecutor().execute(() -> {
                     try {
                         Map<?, ?> rawMediaItem = (Map<?, ?>)args.get("mediaItem");
@@ -786,18 +787,17 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
                 break;
             }
             case "setQueue": {
-                Handler handler = new Handler(Looper.getMainLooper());
                 Executors.newSingleThreadExecutor().execute(() -> {
-                     try {
-                         @SuppressWarnings("unchecked") List<Map<?, ?>> rawQueue = (List<Map<?, ?>>) args.get("queue");
-                         List<MediaSessionCompat.QueueItem> queue = raw2queue(rawQueue);
-                         AudioService.instance.setQueue(queue);
-                         handler.post(() -> result.success(null));
-                     } catch (Exception e) {
-                         handler.post(() -> {
-                             result.error("UNEXPECTED_ERROR", "Unexpected error", Log.getStackTraceString(e));
-                         });
-                     }
+                    try {
+                        @SuppressWarnings("unchecked") List<Map<?, ?>> rawQueue = (List<Map<?, ?>>) args.get("queue");
+                        List<MediaSessionCompat.QueueItem> queue = raw2queue(rawQueue);
+                        AudioService.instance.setQueue(queue);
+                        handler.post(() -> result.success(null));
+                    } catch (Exception e) {
+                        handler.post(() -> {
+                            result.error("UNEXPECTED_ERROR", "Unexpected error", Log.getStackTraceString(e));
+                        });
+                    }
                 });
                 break;
             }


### PR DESCRIPTION
Fixes https://github.com/ryanheise/audio_service/issues/667

You should be able to test this by cloning this https://github.com/nt4f04unds-archive/issues/tree/audio_service_667 with
```
git clone -b audio_service_667 --single-branch https://github.com/nt4f04unds-archive/issues.git
```

* there's roaming red box to detect janks
* Android Auto is enabled to test that nothing breaks

How I tested on my device (old Android 9):
1. One tap on item - without patch janks, with patch no jank
2. Fast taps - without patch hardly janks, with patch fps drops

Unrelated to this PR, but while testing I noticed that for some reason Android 11 updates artist in notification less often than the title