### PR TITLE
Cleanup web implementation

### DIFF
--- a/audio_service_web/lib/audio_service_web.dart
+++ b/audio_service_web/lib/audio_service_web.dart
@@ -12,7 +12,7 @@ class AudioServiceWeb extends AudioServicePlatform {
   }
 
   bool _loggedNotSupported = false;
-  bool checkMediaSessionSupported() {
+  bool _checkMediaSessionSupported() {
     final supported = js.context.hasProperty('MediaSession');
     if (!supported && !_loggedNotSupported) {
       _loggedNotSupported = true;
@@ -27,67 +27,75 @@ class AudioServiceWeb extends AudioServicePlatform {
 
   @override
   Future<void> configure(ConfigureRequest request) async {
-    checkMediaSessionSupported();
+    _checkMediaSessionSupported();
   }
 
   @override
   Future<void> setState(SetStateRequest request) async {
-    if (!checkMediaSessionSupported()) {
+    if (!_checkMediaSessionSupported()) {
       return;
     }
-    final session = html.window.navigator.mediaSession!;
-    for (final control in request.state.controls) {
-      switch (control.action) {
-        case MediaActionMessage.play:
-          session.setActionHandler(
-            'play',
-            () => handlerCallbacks?.play(const PlayRequest()),
-          );
-          break;
-        case MediaActionMessage.pause:
-          session.setActionHandler(
-            'pause',
-            () => handlerCallbacks?.pause(const PauseRequest()),
-          );
-          break;
-        case MediaActionMessage.skipToPrevious:
-          session.setActionHandler(
-            'previoustrack',
-            () =>
-                handlerCallbacks?.skipToPrevious(const SkipToPreviousRequest()),
-          );
-          break;
-        case MediaActionMessage.skipToNext:
-          session.setActionHandler(
-            'nexttrack',
-            () => handlerCallbacks?.skipToNext(const SkipToNextRequest()),
-          );
-          break;
-        // The naming convention here is a bit odd but seekbackward seems more
-        // analagous to rewind than seekBackward
-        case MediaActionMessage.rewind:
-          session.setActionHandler(
-            'seekbackward',
-            () => handlerCallbacks?.rewind(const RewindRequest()),
-          );
-          break;
-        case MediaActionMessage.fastForward:
-          session.setActionHandler(
-            'seekforward',
-            () => handlerCallbacks?.fastForward(const FastForwardRequest()),
-          );
-          break;
-        case MediaActionMessage.stop:
-          session.setActionHandler(
-            'stop',
-            () => handlerCallbacks?.stop(const StopRequest()),
-          );
-          break;
-        default:
-          // no-op
-          break;
-      }
 
+    try {
+      final session = html.window.navigator.mediaSession!;
+      for (final control in request.state.controls) {
+        switch (control.action) {
+          case MediaActionMessage.play:
+            session.setActionHandler(
+              'play',
+              () => handlerCallbacks?.play(const PlayRequest()),
+            );
+            break;
+          case MediaActionMessage.pause:
+            session.setActionHandler(
+              'pause',
+              () => handlerCallbacks?.pause(const PauseRequest()),
+            );
+            break;
+          case MediaActionMessage.skipToPrevious:
+            session.setActionHandler(
+              'previoustrack',
+              () => handlerCallbacks
+                  ?.skipToPrevious(const SkipToPreviousRequest()),
+            );
+            break;
+          case MediaActionMessage.skipToNext:
+            session.setActionHandler(
+              'nexttrack',
+              () => handlerCallbacks?.skipToNext(const SkipToNextRequest()),
+            );
+            break;
+          // The naming convention here is a bit odd but seekbackward seems more
+          // analagous to rewind than seekBackward
+          case MediaActionMessage.rewind:
+            session.setActionHandler(
+              'seekbackward',
+              () => handlerCallbacks?.rewind(const RewindRequest()),
+            );
+            break;
+          case MediaActionMessage.fastForward:
+            session.setActionHandler(
+              'seekforward',
+              () => handlerCallbacks?.fastForward(const FastForwardRequest()),
+            );
+            break;
+          case MediaActionMessage.stop:
+            session.setActionHandler(
+              'stop',
+              () => handlerCallbacks?.stop(const StopRequest()),
+            );
+            break;
+          default:
+            // no-op
+            break;
+        }
+      }
+    } catch (ex) {
+      // In case some browsers don't have `setActionHandler` implemented.
+      print(ex);
+    }
+
+    try {
       for (final message in request.state.systemActions) {
         switch (message) {
           case MediaActionMessage.seek:
@@ -104,7 +112,12 @@ class AudioServiceWeb extends AudioServicePlatform {
             break;
         }
       }
+    } catch (ex) {
+      // In case some browsers don't have `setActionHandler` implemented.
+      print(ex);
+    }
 
+    try {
       // Update the position
       //
       // Factor out invalid states according to
@@ -123,6 +136,9 @@ class AudioServiceWeb extends AudioServicePlatform {
         playbackRate: request.state.speed,
         position: position.inMilliseconds / 1000,
       ));
+    } catch (ex) {
+      // In case some browsers don't have `setPositionState` implemented.
+      print(ex);
     }
   }
 
@@ -133,7 +149,7 @@ class AudioServiceWeb extends AudioServicePlatform {
 
   @override
   Future<void> setMediaItem(SetMediaItemRequest request) async {
-    if (!checkMediaSessionSupported()) {
+    if (!_checkMediaSessionSupported()) {
       return;
     }
     mediaItem = request.mediaItem;
@@ -154,7 +170,7 @@ class AudioServiceWeb extends AudioServicePlatform {
 
   @override
   Future<void> stopService(StopServiceRequest request) async {
-    if (!checkMediaSessionSupported()) {
+    if (!_checkMediaSessionSupported()) {
       return;
     }
     final session = html.window.navigator.mediaSession!;
@@ -164,7 +180,7 @@ class AudioServiceWeb extends AudioServicePlatform {
 
   @override
   void setHandlerCallbacks(AudioHandlerCallbacks callbacks) {
-    if (!checkMediaSessionSupported()) {
+    if (!_checkMediaSessionSupported()) {
       return;
     }
     // Save this here so that we can modify which handlers are set based

--- a/audio_service_web/lib/audio_service_web.dart
+++ b/audio_service_web/lib/audio_service_web.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 import 'dart:html' as html;
+import 'dart:js' as js;
+import 'dart:js_util';
 
 import 'package:audio_service_platform_interface/audio_service_platform_interface.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
-import 'dart:js' as js;
 import 'js/media_session_web.dart';
 
 class AudioServiceWeb extends AudioServicePlatform {
@@ -11,105 +13,87 @@ class AudioServiceWeb extends AudioServicePlatform {
     AudioServicePlatform.instance = AudioServiceWeb();
   }
 
-  bool _loggedNotSupported = false;
-  bool _checkMediaSessionSupported() {
-    final supported = js.context.hasProperty('MediaSession');
-    if (!supported && !_loggedNotSupported) {
-      _loggedNotSupported = true;
-      print(
-          "[warning] audio_service: MediaSession is not supported in this browser, so plugin is no-op");
-    }
-    return supported;
-  }
+  final _mediaSessionSupported = _SupportChecker(
+    () => js.context.hasProperty('MediaSession'),
+    "MediaSession is not supported in this browser, so plugin is no-op",
+  );
+  final _setPositionStateSupported = _SupportChecker(
+    () => hasProperty(html.window.navigator.mediaSession!, 'setPositionState'),
+    "MediaSession.setPositionState is not supported in this browser",
+  );
 
   AudioHandlerCallbacks? handlerCallbacks;
   MediaItemMessage? mediaItem;
 
   @override
   Future<void> configure(ConfigureRequest request) async {
-    _checkMediaSessionSupported();
+    _mediaSessionSupported.check();
   }
 
   @override
   Future<void> setState(SetStateRequest request) async {
-    if (!_checkMediaSessionSupported()) {
+    if (!_mediaSessionSupported.check()) {
       return;
     }
 
-    try {
-      final session = html.window.navigator.mediaSession!;
-      for (final control in request.state.controls) {
-        switch (control.action) {
-          case MediaActionMessage.play:
-            session.setActionHandler(
-              'play',
-              () => handlerCallbacks?.play(const PlayRequest()),
-            );
-            break;
-          case MediaActionMessage.pause:
-            session.setActionHandler(
-              'pause',
-              () => handlerCallbacks?.pause(const PauseRequest()),
-            );
-            break;
-          case MediaActionMessage.skipToPrevious:
-            session.setActionHandler(
-              'previoustrack',
-              () => handlerCallbacks
-                  ?.skipToPrevious(const SkipToPreviousRequest()),
-            );
-            break;
-          case MediaActionMessage.skipToNext:
-            session.setActionHandler(
-              'nexttrack',
-              () => handlerCallbacks?.skipToNext(const SkipToNextRequest()),
-            );
-            break;
-          // The naming convention here is a bit odd but seekbackward seems more
-          // analagous to rewind than seekBackward
-          case MediaActionMessage.rewind:
-            session.setActionHandler(
-              'seekbackward',
-              () => handlerCallbacks?.rewind(const RewindRequest()),
-            );
-            break;
-          case MediaActionMessage.fastForward:
-            session.setActionHandler(
-              'seekforward',
-              () => handlerCallbacks?.fastForward(const FastForwardRequest()),
-            );
-            break;
-          case MediaActionMessage.stop:
-            session.setActionHandler(
-              'stop',
-              () => handlerCallbacks?.stop(const StopRequest()),
-            );
-            break;
-          default:
-            // no-op
-            break;
-        }
+    final state = request.state;
+
+    if (state.processingState == AudioProcessingStateMessage.idle) {
+      MediaSession.playbackState = MediaSessionPlaybackState.none;
+    } else {
+      if (request.state.playing) {
+        MediaSession.playbackState = MediaSessionPlaybackState.playing;
+      } else {
+        MediaSession.playbackState = MediaSessionPlaybackState.paused;
       }
-    } catch (ex) {
-      // In case some browsers don't have `setActionHandler` implemented.
-      print(ex);
     }
 
-    for (final message in request.state.systemActions) {
-      switch (message) {
-        case MediaActionMessage.seek:
-          try {
-            setActionHandler('seekto', js.allowInterop((ActionResult event) {
-              // Chrome uses seconds
-              handlerCallbacks?.seek(SeekRequest(
-                position:
-                    Duration(milliseconds: (event.seekTime * 1000).round()),
-              ));
-            }));
-          } catch (ex) {
-            // In case some browsers don't have `setActionHandler` implemented.
-            print(ex);
-          }
+    for (final control in state.controls) {
+      switch (control.action) {
+        case MediaActionMessage.play:
+          MediaSession.setActionHandler(
+            MediaActions.play,
+            (details) => handlerCallbacks?.play(const PlayRequest()),
+          );
+          break;
+        case MediaActionMessage.pause:
+          MediaSession.setActionHandler(
+            MediaActions.pause,
+            (details) => handlerCallbacks?.pause(const PauseRequest()),
+          );
+          break;
+        case MediaActionMessage.skipToPrevious:
+          MediaSession.setActionHandler(
+            MediaActions.previoustrack,
+            (details) =>
+                handlerCallbacks?.skipToPrevious(const SkipToPreviousRequest()),
+          );
+          break;
+        case MediaActionMessage.skipToNext:
+          MediaSession.setActionHandler(
+            MediaActions.nexttrack,
+            (details) =>
+                handlerCallbacks?.skipToNext(const SkipToNextRequest()),
+          );
+          break;
+        case MediaActionMessage.rewind:
+          MediaSession.setActionHandler(
+            MediaActions.seekbackward,
+            (details) => handlerCallbacks?.rewind(const RewindRequest()),
+          );
+          break;
+        case MediaActionMessage.fastForward:
+          MediaSession.setActionHandler(
+            MediaActions.seekforward,
+            (details) =>
+                handlerCallbacks?.fastForward(const FastForwardRequest()),
+          );
+          break;
+        case MediaActionMessage.stop:
+          MediaSession.setActionHandler(
+            MediaActions.stop,
+            (details) => handlerCallbacks?.stop(const StopRequest()),
+          );
           break;
         default:
           // no-op
@@ -117,29 +101,44 @@ class AudioServiceWeb extends AudioServicePlatform {
       }
     }
 
-    // Update the position
-    //
-    // Factor out invalid states according to
-    // https://developer.mozilla.org/en-US/docs/Web/API/MediaSession/setPositionState#exceptions
-    var duration = Duration.zero;
-    var position = request.state.updatePosition;
-    if (mediaItem != null) {
-      duration = mediaItem!.duration ?? Duration.zero;
-    }
-    if (position > duration) {
-      position = duration;
+    for (final message in state.systemActions) {
+      switch (message) {
+        case MediaActionMessage.seek:
+          MediaSession.setActionHandler('seekto',
+              (MediaSessionActionDetails details) {
+            // Browsers use seconds
+            handlerCallbacks?.seek(SeekRequest(
+              position:
+                  Duration(milliseconds: (details.seekTime * 1000).round()),
+            ));
+          });
+          break;
+        default:
+          // no-op
+          break;
+      }
     }
 
-    try {
-      // Chrome expects for seconds
-      setPositionState(PositionState(
+    if (_setPositionStateSupported.check()) {
+      // Update the position
+      //
+      // Factor out invalid states according to
+      // https://developer.mozilla.org/en-US/docs/Web/API/MediaSession/setPositionState#exceptions
+      var duration = Duration.zero;
+      var position = state.updatePosition;
+      if (mediaItem != null) {
+        duration = mediaItem!.duration ?? Duration.zero;
+      }
+      if (position > duration) {
+        position = duration;
+      }
+
+      // Browsers expect for seconds
+      MediaSession.setPositionState(MediaPositionState(
         duration: duration.inMilliseconds / 1000,
-        playbackRate: request.state.speed,
+        playbackRate: state.speed,
         position: position.inMilliseconds / 1000,
       ));
-    } catch (ex) {
-      // In case some browsers don't have `setPositionState` implemented.
-      print(ex);
     }
   }
 
@@ -150,13 +149,13 @@ class AudioServiceWeb extends AudioServicePlatform {
 
   @override
   Future<void> setMediaItem(SetMediaItemRequest request) async {
-    if (!_checkMediaSessionSupported()) {
+    if (!_mediaSessionSupported.check()) {
       return;
     }
     mediaItem = request.mediaItem;
     final artUri = mediaItem!.artUri;
 
-    metadata = html.MediaMetadata(<String, dynamic>{
+    MediaSession.metadata = html.MediaMetadata(<String, dynamic>{
       'album': mediaItem!.album,
       'title': mediaItem!.title,
       'artist': mediaItem!.artist,
@@ -171,7 +170,7 @@ class AudioServiceWeb extends AudioServicePlatform {
 
   @override
   Future<void> stopService(StopServiceRequest request) async {
-    if (!_checkMediaSessionSupported()) {
+    if (!_mediaSessionSupported.check()) {
       return;
     }
     final session = html.window.navigator.mediaSession!;
@@ -181,11 +180,29 @@ class AudioServiceWeb extends AudioServicePlatform {
 
   @override
   void setHandlerCallbacks(AudioHandlerCallbacks callbacks) {
-    if (!_checkMediaSessionSupported()) {
+    if (!_mediaSessionSupported.check()) {
       return;
     }
     // Save this here so that we can modify which handlers are set based
     // on which actions are enabled
     handlerCallbacks = callbacks;
+  }
+}
+
+/// Runs a [check], and prints a warning the first time check doesn't pass.
+class _SupportChecker {
+  final String _warningMessage;
+  final ValueGetter<bool> _checkCallback;
+
+  _SupportChecker(this._checkCallback, this._warningMessage);
+
+  bool _logged = false;
+  bool check() {
+    final result = _checkCallback();
+    if (!_logged && !result) {
+      _logged = true;
+      print("[warning] audio_service: $_warningMessage");
+    }
+    return result;
   }
 }

--- a/audio_service_web/lib/audio_service_web.dart
+++ b/audio_service_web/lib/audio_service_web.dart
@@ -16,7 +16,8 @@ class AudioServiceWeb extends AudioServicePlatform {
     final supported = js.context.hasProperty('MediaSession');
     if (!supported && !_loggedNotSupported) {
       _loggedNotSupported = true;
-      print("[warning] audio_service: MediaSession is not supported in this browser, so plugin is no-op");
+      print(
+          "[warning] audio_service: MediaSession is not supported in this browser, so plugin is no-op");
     }
     return supported;
   }

--- a/audio_service_web/lib/audio_service_web.dart
+++ b/audio_service_web/lib/audio_service_web.dart
@@ -35,7 +35,6 @@ class AudioServiceWeb extends AudioServicePlatform {
       return;
     }
     final session = html.window.navigator.mediaSession!;
-    print(session);
     for (final control in request.state.controls) {
       switch (control.action) {
         case MediaActionMessage.play:

--- a/audio_service_web/lib/audio_service_web.dart
+++ b/audio_service_web/lib/audio_service_web.dart
@@ -76,8 +76,10 @@ class AudioServiceWeb extends AudioServicePlatform {
         switch (message) {
           case MediaActionMessage.seek:
             setActionHandler('seekto', js.allowInterop((ActionResult event) {
+              // Chrome uses seconds
               handlerCallbacks?.seek(SeekRequest(
-                position: Duration(seconds: event.seekTime.toInt()),
+                position:
+                    Duration(milliseconds: (event.seekTime * 1000).round()),
               ));
             }));
             break;
@@ -99,10 +101,11 @@ class AudioServiceWeb extends AudioServicePlatform {
       if (position > duration) {
         position = duration;
       }
+      // Chrome expects for seconds
       setPositionState(PositionState(
-        duration: duration.inSeconds.toDouble(),
+        duration: duration.inMilliseconds / 1000,
         playbackRate: request.state.speed,
-        position: position.inSeconds.toDouble(),
+        position: position.inMilliseconds / 1000,
       ));
     }
   }

--- a/audio_service_web/lib/audio_service_web.dart
+++ b/audio_service_web/lib/audio_service_web.dart
@@ -52,46 +52,46 @@ class AudioServiceWeb extends AudioServicePlatform {
       switch (control.action) {
         case MediaActionMessage.play:
           MediaSession.setActionHandler(
-            MediaActions.play,
+            MediaSessionActions.play,
             (details) => handlerCallbacks?.play(const PlayRequest()),
           );
           break;
         case MediaActionMessage.pause:
           MediaSession.setActionHandler(
-            MediaActions.pause,
+            MediaSessionActions.pause,
             (details) => handlerCallbacks?.pause(const PauseRequest()),
           );
           break;
         case MediaActionMessage.skipToPrevious:
           MediaSession.setActionHandler(
-            MediaActions.previoustrack,
+            MediaSessionActions.previoustrack,
             (details) =>
                 handlerCallbacks?.skipToPrevious(const SkipToPreviousRequest()),
           );
           break;
         case MediaActionMessage.skipToNext:
           MediaSession.setActionHandler(
-            MediaActions.nexttrack,
+            MediaSessionActions.nexttrack,
             (details) =>
                 handlerCallbacks?.skipToNext(const SkipToNextRequest()),
           );
           break;
         case MediaActionMessage.rewind:
           MediaSession.setActionHandler(
-            MediaActions.seekbackward,
+            MediaSessionActions.seekbackward,
             (details) => handlerCallbacks?.rewind(const RewindRequest()),
           );
           break;
         case MediaActionMessage.fastForward:
           MediaSession.setActionHandler(
-            MediaActions.seekforward,
+            MediaSessionActions.seekforward,
             (details) =>
                 handlerCallbacks?.fastForward(const FastForwardRequest()),
           );
           break;
         case MediaActionMessage.stop:
           MediaSession.setActionHandler(
-            MediaActions.stop,
+            MediaSessionActions.stop,
             (details) => handlerCallbacks?.stop(const StopRequest()),
           );
           break;
@@ -134,7 +134,7 @@ class AudioServiceWeb extends AudioServicePlatform {
       }
 
       // Browsers expect for seconds
-      MediaSession.setPositionState(MediaPositionState(
+      MediaSession.setPositionState(MediaSessionPositionState(
         duration: duration.inMilliseconds / 1000,
         playbackRate: state.speed,
         position: position.inMilliseconds / 1000,

--- a/audio_service_web/lib/audio_service_web.dart
+++ b/audio_service_web/lib/audio_service_web.dart
@@ -75,12 +75,10 @@ class AudioServiceWeb extends AudioServicePlatform {
       for (final message in request.state.systemActions) {
         switch (message) {
           case MediaActionMessage.seek:
-            setActionHandler('seekto', js.allowInterop((ActionResult ev) {
-              // Chrome uses seconds for whatever reason
+            setActionHandler('seekto', js.allowInterop((ActionResult event) {
               handlerCallbacks?.seek(SeekRequest(
-                  position: Duration(
-                milliseconds: (ev.seekTime * 1000).round(),
-              )));
+                position: Duration(seconds: event.seekTime.toInt()),
+              ));
             }));
             break;
           default:

--- a/audio_service_web/lib/audio_service_web.dart
+++ b/audio_service_web/lib/audio_service_web.dart
@@ -19,77 +19,69 @@ class AudioServiceWeb extends AudioServicePlatform {
 
   @override
   Future<void> setState(SetStateRequest request) async {
-    print('Setting state');
     final session = html.window.navigator.mediaSession!;
     for (final control in request.state.controls) {
-      try {
-        switch (control.action) {
-          case MediaActionMessage.play:
-            session.setActionHandler(
-              'play',
-              () => handlerCallbacks?.play(const PlayRequest()),
-            );
-            break;
-          case MediaActionMessage.pause:
-            session.setActionHandler(
-              'pause',
-              () => handlerCallbacks?.pause(const PauseRequest()),
-            );
-            break;
-          case MediaActionMessage.skipToPrevious:
-            session.setActionHandler(
-              'previoustrack',
-              () => handlerCallbacks
-                  ?.skipToPrevious(const SkipToPreviousRequest()),
-            );
-            break;
-          case MediaActionMessage.skipToNext:
-            session.setActionHandler(
-              'nexttrack',
-              () => handlerCallbacks?.skipToNext(const SkipToNextRequest()),
-            );
-            break;
-          // The naming convention here is a bit odd but seekbackward seems more
-          // analagous to rewind than seekBackward
-          case MediaActionMessage.rewind:
-            session.setActionHandler(
-              'seekbackward',
-              () => handlerCallbacks?.rewind(const RewindRequest()),
-            );
-            break;
-          case MediaActionMessage.fastForward:
-            session.setActionHandler(
-              'seekforward',
-              () => handlerCallbacks?.fastForward(const FastForwardRequest()),
-            );
-            break;
-          case MediaActionMessage.stop:
-            session.setActionHandler(
-              'stop',
-              () => handlerCallbacks?.stop(const StopRequest()),
-            );
-            break;
-          default:
-            // no-op
-            break;
-        }
-      } catch (e) {
-        // TODO: handle this somehow?
+      switch (control.action) {
+        case MediaActionMessage.play:
+          session.setActionHandler(
+            'play',
+            () => handlerCallbacks?.play(const PlayRequest()),
+          );
+          break;
+        case MediaActionMessage.pause:
+          session.setActionHandler(
+            'pause',
+            () => handlerCallbacks?.pause(const PauseRequest()),
+          );
+          break;
+        case MediaActionMessage.skipToPrevious:
+          session.setActionHandler(
+            'previoustrack',
+            () =>
+                handlerCallbacks?.skipToPrevious(const SkipToPreviousRequest()),
+          );
+          break;
+        case MediaActionMessage.skipToNext:
+          session.setActionHandler(
+            'nexttrack',
+            () => handlerCallbacks?.skipToNext(const SkipToNextRequest()),
+          );
+          break;
+        // The naming convention here is a bit odd but seekbackward seems more
+        // analagous to rewind than seekBackward
+        case MediaActionMessage.rewind:
+          session.setActionHandler(
+            'seekbackward',
+            () => handlerCallbacks?.rewind(const RewindRequest()),
+          );
+          break;
+        case MediaActionMessage.fastForward:
+          session.setActionHandler(
+            'seekforward',
+            () => handlerCallbacks?.fastForward(const FastForwardRequest()),
+          );
+          break;
+        case MediaActionMessage.stop:
+          session.setActionHandler(
+            'stop',
+            () => handlerCallbacks?.stop(const StopRequest()),
+          );
+          break;
+        default:
+          // no-op
+          break;
       }
+
       for (final message in request.state.systemActions) {
         switch (message) {
           case MediaActionMessage.seek:
-            try {
-              setActionHandler('seekto', js.allowInterop((ActionResult ev) {
-                // Chrome uses seconds for whatever reason
-                handlerCallbacks?.seek(SeekRequest(
-                    position: Duration(
-                  milliseconds: (ev.seekTime * 1000).round(),
-                )));
-              }));
-            } catch (e) {
-              // TODO: handle this somehow?
-            }
+            setActionHandler('seekto', js.allowInterop((ActionResult ev) {
+              // Chrome uses seconds for whatever reason
+              handlerCallbacks?.seek(SeekRequest(
+                  position: Duration(
+                milliseconds: (ev.seekTime * 1000).round(),
+              )));
+            }));
             break;
           default:
             // no-op
@@ -97,28 +89,29 @@ class AudioServiceWeb extends AudioServicePlatform {
         }
       }
 
-      try {
-        // Dart also doesn't expose setPositionState
-        if (mediaItem != null) {
-          //print(
-          //    'Setting positionState Duration(${mediaItem!.duration?.inSeconds}), PlaybackRate(${args[6] ?? 1.0}), Position(${Duration(milliseconds: args[4])?.inSeconds})');
-
-          // Chrome looks for seconds for some reason
-          setPositionState(PositionState(
-            duration: (mediaItem!.duration?.inMilliseconds ?? 0) / 1000,
-            playbackRate: request.state.speed,
-            position: request.state.updatePosition.inMilliseconds / 1000,
-          ));
-        }
-      } catch (e) {
-        print(e);
+      // Update the position
+      //
+      // Factor out invalid states according to
+      // https://developer.mozilla.org/en-US/docs/Web/API/MediaSession/setPositionState#exceptions
+      var duration = Duration.zero;
+      var position = request.state.updatePosition;
+      if (mediaItem != null) {
+        duration = mediaItem!.duration ?? Duration.zero;
       }
+      if (position > duration) {
+        position = duration;
+      }
+      setPositionState(PositionState(
+        duration: duration.inSeconds.toDouble(),
+        playbackRate: request.state.speed,
+        position: position.inSeconds.toDouble(),
+      ));
     }
   }
 
   @override
   Future<void> setQueue(SetQueueRequest request) async {
-    //no-op there is not a queue concept on the web
+    // no-op as there is not a queue concept on the web
   }
 
   @override
@@ -126,23 +119,17 @@ class AudioServiceWeb extends AudioServicePlatform {
     mediaItem = request.mediaItem;
     final artUri = mediaItem!.artUri;
 
-    print('setting media item!');
-
-    try {
-      metadata = html.MediaMetadata(<String, dynamic>{
-        'album': mediaItem!.album,
-        'title': mediaItem!.title,
-        'artist': mediaItem!.artist,
-        'artwork': [
-          {
-            'src': artUri,
-            'sizes': '512x512',
-          }
-        ],
-      });
-    } catch (e) {
-      print('Metadata failed $e');
-    }
+    metadata = html.MediaMetadata(<String, dynamic>{
+      'album': mediaItem!.album,
+      'title': mediaItem!.title,
+      'artist': mediaItem!.artist,
+      'artwork': [
+        {
+          'src': artUri,
+          'sizes': '512x512',
+        }
+      ],
+    });
   }
 
   @override

--- a/audio_service_web/lib/js/media_session_web.dart
+++ b/audio_service_web/lib/js/media_session_web.dart
@@ -43,7 +43,7 @@ class MediaSession {
 
   /// Sets the current playback position and speed of the media currently being presented.
   @JS('setPositionState')
-  external static void setPositionState(MediaPositionState? state);
+  external static void setPositionState(MediaSessionPositionState? state);
 }
 
 /// Media session playback state types.
@@ -64,8 +64,8 @@ abstract class MediaSessionPlaybackState {
 }
 
 /// Actions that the user may perform in a media session.
-abstract class MediaActions {
-  MediaActions._();
+abstract class MediaSessionActions {
+  MediaSessionActions._();
 
   static const play = 'play';
   static const pause = 'pause';
@@ -132,10 +132,10 @@ class MediaSessionActionDetails {
 
 /// A representation of the current playback.
 ///
-/// The dictionary parameter for [setPositionState].
+/// The dictionary parameter for [MediaSession.setPositionState].
 @JS()
 @anonymous
-class MediaPositionState {
+class MediaSessionPositionState {
   /// Duration in seconds.
   external double get duration;
 
@@ -151,7 +151,7 @@ class MediaPositionState {
   external double get position;
 
   /// Creates the position state.
-  external factory MediaPositionState({
+  external factory MediaSessionPositionState({
     double? duration,
     double? playbackRate,
     double? position,

--- a/audio_service_web/lib/js/media_session_web.dart
+++ b/audio_service_web/lib/js/media_session_web.dart
@@ -1,39 +1,159 @@
-@JS('navigator.mediaSession')
+/// The interface to the Media Session API, `navigator.mediaSession`.
+///
+/// Useful links:
+///  * W3C specification https://w3c.github.io/mediasession/
+///  * MDN documentation https://developer.mozilla.org/en-US/docs/Web/API/MediaSession/
+@JS()
 library media_session_web;
 
+import 'dart:js' as js;
 import 'dart:html' as html;
-
 import 'package:js/js.dart';
 
-@JS('setActionHandler')
-external void setActionHandler(String action, Function(ActionResult) callback);
+/// The interface to the Media Session API which allows a web page
+/// to provide custom behaviors for standard media playback interactions,
+/// and to report metadata that can be sent by the user agent
+/// to the device or operating system for presentation in standardized
+/// user interface elements.
+@JS('navigator.mediaSession')
+class MediaSession {
+  /// Returns an instance of [html.MediaMetadata], which contains rich media
+  /// metadata for display in a platform UI.
+  @JS('metadata')
+  external static html.MediaMetadata metadata;
 
-@JS('setPositionState')
-external void setPositionState(PositionState state);
+  /// Indicates whether the current media session is playing.
+  ///
+  /// See [MediaSessionPlaybackState] for possible values.
+  @JS('playbackState')
+  external static String playbackState;
 
-@JS()
-@anonymous
-class ActionResult {
-  external String get action;
-  external double get seekTime;
+  /// Sets an action handler for a media session action, such as play or pause.
+  static void setActionHandler(
+    String action,
+    MediaSessionActionHandler callback,
+  ) =>
+      _setActionHandler(action, js.allowInterop(callback));
 
-  external factory ActionResult({String? action, double? seekTime});
+  @JS('setActionHandler')
+  external static void _setActionHandler(
+    String action,
+    MediaSessionActionHandler callback,
+  );
+
+  /// Sets the current playback position and speed of the media currently being presented.
+  @JS('setPositionState')
+  external static void setPositionState(MediaPositionState? state);
 }
 
+/// Media session playback state types.
+///
+/// See [MediaSession.playbackState].
+abstract class MediaSessionPlaybackState {
+  MediaSessionPlaybackState._();
+
+  /// The browsing context doesn't currently know the current playback
+  /// state, or the playback state is not available at this time.
+  static const none = 'none';
+
+  /// The browser's media session is currently paused. Playback may be resumed.
+  static const paused = 'paused';
+
+  /// The browser's media session is currently playing media, which can be paused.
+  static const playing = 'playing';
+}
+
+/// Actions that the user may perform in a media session.
+abstract class MediaActions {
+  MediaActions._();
+
+  static const play = 'play';
+  static const pause = 'pause';
+  static const seekbackward = 'seekbackward';
+  static const seekforward = 'seekforward';
+  static const previoustrack = 'previoustrack';
+  static const nexttrack = 'nexttrack';
+  static const skipad = 'skipad';
+  static const stop = 'stop';
+  static const seekto = 'seekto';
+  static const togglemicrophone = 'togglemicrophone';
+  static const togglecamera = 'togglecamera';
+  static const hangup = 'hangup';
+}
+
+/// A callback signature for the [MediaSession.setActionHandler].
+typedef MediaSessionActionHandler = Function(MediaSessionActionDetails);
+
+/// Specifies the type of action which needs to be performed
+/// as well as the data needed to perform the action.
+///
+/// The dictionary parameter for [MediaSessionActionHandler] callback.
 @JS()
 @anonymous
-class PositionState {
+class MediaSessionActionDetails {
+  /// An action type string taken from the [MediaActions], indicating which
+  /// type of action needs to be performed.
+  external String get action;
+
+  /// Indicates whether or not to perform a "fast" seek.
+  ///
+  /// A `seekto` action may optionally include this property.
+  ///
+  /// A "fast" seek is a seek being performed in a rapid sequence, such as when
+  /// fast-forwarding or reversing through the media, rapidly skipping through it.
+  ///
+  /// This property can be used to indicate that you should use the shortest possible
+  /// method to seek the media. This property is not included on the final action in
+  /// the seek sequence in this situation.
+  external bool get fastSeek;
+
+  /// If the action is either `seekforward` or `seekbackward`
+  /// and this property is present, it is a floating point value which indicates
+  /// the seek interval.
+  ///
+  /// If this property isn't present, those actions should choose a reasonable
+  /// default interval.
+  external double get seekOffset;
+
+  /// If the action is `seekto`, this property is present and
+  /// indicates the absolute time within the media to move the playback position to.
+  ///
+  /// This property is not present for other action types.
+  external double get seekTime;
+
+  /// Creates the details.
+  external factory MediaSessionActionDetails({
+    String? action,
+    bool? fastSeek,
+    double? seekOffset,
+    double? seekTime,
+  });
+}
+
+/// A representation of the current playback.
+///
+/// The dictionary parameter for [setPositionState].
+@JS()
+@anonymous
+class MediaPositionState {
+  /// Duration in seconds.
   external double get duration;
+
+  /// Playback rate.
+  ///
+  /// Can be positive to represent forward playback or negative to
+  /// represent backwards playback.
+  ///
+  /// Cannot be zero.
   external double get playbackRate;
+
+  /// Position in seconds.
   external double get position;
-  external factory PositionState({
+
+  /// Creates the position state.
+  external factory MediaPositionState({
     double? duration,
     double? playbackRate,
     double? position,
   });
 }
-
-@JS('metadata')
-external set metadata(html.MediaMetadata metadata);
-
-// TODO: document this also create a library-level doc comment (dartdoc shows a warning related to this)


### PR DESCRIPTION
* It's bad to catch exceptions just to reprint them or swallow, unless absolutely necessary
* Fixed `setPositionState` call with invalid states, like media item without duration
* Removed `print`s 