### PR TITLE
Test invocation parameters

### DIFF
--- a/audio_service/lib/audio_service.dart
+++ b/audio_service/lib/audio_service.dart
@@ -2852,16 +2852,16 @@ extension _MediaButtonMessageExtension on MediaButtonMessage {
 /// An enum of volume direction controls on Android.
 class AndroidVolumeDirection {
   /// Lower the ringer volume.
-  static final lower = AndroidVolumeDirection._(-1);
+  static const lower = AndroidVolumeDirection._(-1);
 
   /// Keep the previous ringer volume.
-  static final same = AndroidVolumeDirection._(0);
+  static const same = AndroidVolumeDirection._(0);
 
   /// Raise the ringer volume.
-  static final raise = AndroidVolumeDirection._(1);
+  static const raise = AndroidVolumeDirection._(1);
 
   /// A map of indices to values.
-  static final values = <int, AndroidVolumeDirection>{
+  static const values = <int, AndroidVolumeDirection>{
     -1: lower,
     0: same,
     1: raise,
@@ -2870,7 +2870,7 @@ class AndroidVolumeDirection {
   /// The index for this enum value.
   final int index;
 
-  AndroidVolumeDirection._(this.index);
+  const AndroidVolumeDirection._(this.index);
 
   @override
   String toString() => '$index';

--- a/audio_service/test/data_classes_test.dart
+++ b/audio_service/test/data_classes_test.dart
@@ -2,7 +2,7 @@ import 'package:audio_service/audio_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fake_async/fake_async.dart';
 
-const asciiSquare = '▮';
+import 'stubs.dart';
 
 void main() {
   group('$PlaybackState $asciiSquare', () {

--- a/audio_service/test/isolates_test.dart
+++ b/audio_service/test/isolates_test.dart
@@ -4,241 +4,330 @@ import 'package:audio_service/audio_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:rxdart/rxdart.dart';
 
+import 'stubs.dart';
+
 Isolate? isolate;
 
-class Data {
-  static final playbackState = PlaybackState(
-    processingState: AudioProcessingState.buffering,
-    playing: true,
-    controls: [MediaControl.pause],
-    androidCompactActionIndices: [0],
-    systemActions: {MediaAction.seek},
-    updatePosition: const Duration(seconds: 30),
-    bufferedPosition: const Duration(seconds: 35),
-    speed: 1.5,
-    updateTime: DateTime.now(),
-    errorCode: 3,
-    errorMessage: 'error message',
-    repeatMode: AudioServiceRepeatMode.all,
-    shuffleMode: AudioServiceShuffleMode.all,
-    captioningEnabled: true,
-    queueIndex: 0,
-  );
-  static final playbackStates = [
-    PlaybackState(playing: true),
-    PlaybackState(processingState: AudioProcessingState.buffering),
-    PlaybackState(speed: 1.5),
-  ];
-  static const query = 'query';
-  static final uri = Uri.parse('https://example.com/foo');
-  static const mediaId = '1';
-  static const mediaItem = MediaItem(id: '1', title: 'title1');
-  static final mediaItems = [
-    const MediaItem(id: '1', title: 'title1'),
-    const MediaItem(id: '2', title: 'title2'),
-    const MediaItem(id: '3', title: 'title3'),
-  ];
-  static final remotePlaybackInfo = RemoteAndroidPlaybackInfo(
-    volumeControlType: AndroidVolumeControlType.absolute,
-    maxVolume: 10,
-    volume: 5,
-  );
-}
-
 void main() {
-  group('isolates', () {
-    late AudioHandler proxy;
+  late AudioHandler proxy;
 
-    late bool spawningIsolate;
+  late bool spawningIsolate;
 
-    setUp(() async {
-      if (spawningIsolate) {
-        await runIsolateHandler();
-      } else {
-        IsolatedAudioHandler(_MockAudioHandler());
-      }
-      proxy = await IsolatedAudioHandler.lookup();
-    });
+  setUp(() async {
+    if (spawningIsolate) {
+      await runIsolateHandler();
+    } else {
+      IsolatedAudioHandler(_MockAudioHandler());
+    }
+    proxy = await IsolatedAudioHandler.lookup();
+  });
 
-    tearDown(() async {
-      await proxy.unregister();
-      if (spawningIsolate) {
-        await killIsolate();
-      }
-    });
-
-    // We need to run the tests not only in different isolates but also in the
-    // same isolate since coverage is only collected by the main isolate:
-    // https://github.com/dart-lang/test/issues/1108
-    for (var differentIsolate in [true, false]) {
-      spawningIsolate = differentIsolate;
-      final isolateLabel =
-          differentIsolate ? ' (different isolate)' : ' (same isolate)';
-
-      test('init $isolateLabel', () async {
-        //expect(await proxy.playbackState.first, PlaybackState());
-        expect(await proxy.queue.first, const <MediaItem>[]);
-        expect(await proxy.queueTitle.first, '');
-        expect(await proxy.mediaItem.first, null);
-        expect(proxy.ratingStyle.hasValue, false);
-        expect(proxy.androidPlaybackInfo.hasValue, false);
-        expect(proxy.customState.hasValue, false);
-      });
-
-      test('method invocations $isolateLabel', () async {
-        Future<void> testMethod(String method, dynamic Function() function,
-            {dynamic expectedResult}) async {
-          final startCount = await proxy.count(method);
-          final dynamic result = await function();
-          expect(await proxy.count(method), startCount + 1);
-          if (expectedResult != null) {
-            expect(result, expectedResult);
-          }
-        }
-
-        await testMethod('prepare', () => proxy.prepare());
-        await testMethod('prepareFromMediaId',
-            () => proxy.prepareFromMediaId('1', <String, dynamic>{}));
-        await testMethod('prepareFromSearch',
-            () => proxy.prepareFromSearch(Data.query, <String, dynamic>{}));
-        await testMethod('prepareFromUri',
-            () => proxy.prepareFromUri(Data.uri, <String, dynamic>{}));
-        await testMethod('play', () => proxy.play());
-        await testMethod('playFromMediaId',
-            () => proxy.playFromMediaId(Data.mediaId, <String, dynamic>{}));
-        await testMethod('playFromSearch',
-            () => proxy.playFromSearch(Data.query, <String, dynamic>{}));
-        await testMethod('playFromUri',
-            () => proxy.playFromUri(Data.uri, <String, dynamic>{}));
-        await testMethod(
-            'playMediaItem', () => proxy.playMediaItem(Data.mediaItem));
-        await testMethod('pause', () => proxy.pause());
-        await testMethod('click', () => proxy.click());
-        await testMethod('stop', () => proxy.stop());
-        await testMethod(
-            'addQueueItem', () => proxy.addQueueItem(Data.mediaItem));
-        await testMethod(
-            'addQueueItems', () => proxy.addQueueItems(Data.mediaItems));
-        await testMethod(
-            'insertQueueItem', () => proxy.insertQueueItem(0, Data.mediaItem));
-        await testMethod(
-            'updateQueue', () => proxy.updateQueue(Data.mediaItems));
-        await testMethod(
-            'updateMediaItem', () => proxy.updateMediaItem(Data.mediaItem));
-        await testMethod(
-            'removeQueueItem', () => proxy.removeQueueItem(Data.mediaItem));
-        await testMethod('removeQueueItemAt', () => proxy.removeQueueItemAt(0));
-        await testMethod('skipToNext', () => proxy.skipToNext());
-        await testMethod('skipToPrevious', () => proxy.skipToPrevious());
-        await testMethod('fastForward', () => proxy.fastForward());
-        await testMethod('rewind', () => proxy.rewind());
-        await testMethod('skipToQueueItem', () => proxy.skipToQueueItem(0));
-        await testMethod('seek', () => proxy.seek(Duration.zero));
-        await testMethod(
-            'setRating',
-            () => proxy.setRating(
-                const Rating.newHeartRating(true), <String, dynamic>{}));
-        await testMethod(
-            'setCaptioningEnabled', () => proxy.setCaptioningEnabled(true));
-        await testMethod('setRepeatMode',
-            () => proxy.setRepeatMode(AudioServiceRepeatMode.all));
-        await testMethod('setShuffleMode',
-            () => proxy.setShuffleMode(AudioServiceShuffleMode.all));
-        await testMethod('seekBackward', () => proxy.seekBackward(true));
-        await testMethod('seekForward', () => proxy.seekForward(true));
-        await testMethod('setSpeed', () => proxy.setSpeed(1.5));
-        await testMethod('onTaskRemoved', () => proxy.onTaskRemoved());
-        await testMethod(
-            'onNotificationDeleted', () => proxy.onNotificationDeleted());
-        await testMethod('getChildren',
-            () => proxy.getChildren(Data.mediaId, <String, dynamic>{}),
-            expectedResult: Data.mediaItems);
-        await testMethod('subscribeToChildren',
-            () => proxy.subscribeToChildren(Data.mediaId));
-        await testMethod('getMediaItem', () => proxy.getMediaItem(Data.mediaId),
-            expectedResult: Data.mediaItem);
-        await testMethod(
-            'search', () => proxy.search(Data.query, <String, dynamic>{}),
-            expectedResult: Data.mediaItems);
-        await testMethod(
-            'androidSetRemoteVolume', () => proxy.androidSetRemoteVolume(3));
-        await testMethod(
-            'androidAdjustRemoteVolume',
-            () =>
-                proxy.androidAdjustRemoteVolume(AndroidVolumeDirection.raise));
-        await testMethod('customAction',
-            () => proxy.customAction('echo', <String, dynamic>{'arg': 'foo'}),
-            expectedResult: 'foo');
-        await testMethod('customAction',
-            () => proxy.customAction('echo', <String, dynamic>{'arg': 'bar'}),
-            expectedResult: 'bar');
-      });
-
-      test('stream values $isolateLabel', () async {
-        Future<void> testStream<T>(
-            String name, ValueStream<T> stream, T value) async {
-          await proxy.add(name, value);
-          expect(stream.nvalue, value);
-        }
-
-        await testStream(
-            'playbackState', proxy.playbackState, Data.playbackState);
-        await testStream('queue', proxy.queue, Data.mediaItems);
-        await testStream('queueTitle', proxy.queueTitle, 'Queue');
-        await testStream('androidPlaybackInfo', proxy.androidPlaybackInfo,
-            Data.remotePlaybackInfo);
-        await testStream('ratingStyle', proxy.ratingStyle, RatingStyle.heart);
-        await testStream<dynamic>('customState', proxy.customState, 'foo');
-      });
-
-      test('streams $isolateLabel', () async {
-        Future<void> testStream<T>(String name, Stream<T> stream,
-            bool skipFirst, List<T> values) async {
-          final actualValues = <T>[];
-          final subscription =
-              stream.skip(skipFirst ? 1 : 0).listen(actualValues.add);
-          for (var value in values) {
-            await proxy.add(name, value);
-          }
-          expect(actualValues, values);
-          subscription.cancel();
-        }
-
-        await testStream(
-            'playbackState', proxy.playbackState, true, Data.playbackStates);
-        await testStream('queue', proxy.queue, true, [
-          Data.mediaItems,
-          Data.mediaItems
-              .map((item) =>
-                  item.copyWith(displayDescription: '${item.id} description'))
-              .toList(),
-        ]);
-        await testStream('queueTitle', proxy.queueTitle, true, ['a', 'b', 'c']);
-        await testStream('mediaItem', proxy.mediaItem, true, Data.mediaItems);
-        await testStream(
-            'androidPlaybackInfo', proxy.androidPlaybackInfo, false, [
-          Data.remotePlaybackInfo,
-          LocalAndroidPlaybackInfo(),
-        ]);
-        await testStream('ratingStyle', proxy.ratingStyle, false, [
-          RatingStyle.heart,
-          RatingStyle.percentage,
-        ]);
-        await testStream<dynamic>(
-            'customEvent', proxy.customEvent, false, <dynamic>[
-          'a',
-          'b',
-          'c',
-        ]);
-        await testStream<dynamic>(
-            'customState', proxy.customState, false, <dynamic>[
-          'a',
-          'b',
-          'c',
-        ]);
-      });
+  tearDown(() async {
+    await proxy.unregister();
+    if (spawningIsolate) {
+      await killIsolate();
     }
   });
+
+  // We need to run the tests not only in different isolates but also in the
+  // same isolate since coverage is only collected by the main isolate:
+  // https://github.com/dart-lang/test/issues/1108
+  for (var differentIsolate in [true, false]) {
+    spawningIsolate = differentIsolate;
+    final isolateLabel =
+        differentIsolate ? '(different isolate)' : '(same isolate)';
+
+    test('$isolateLabel init', () async {
+      //expect(await proxy.playbackState.first, PlaybackState());
+      expect(await proxy.queue.first, const <MediaItem>[]);
+      expect(await proxy.queueTitle.first, '');
+      expect(await proxy.mediaItem.first, null);
+      expect(proxy.ratingStyle.hasValue, false);
+      expect(proxy.androidPlaybackInfo.hasValue, false);
+      expect(proxy.customState.hasValue, false);
+    });
+
+    group('$isolateLabel method invocations $asciiSquare', () {
+      void testMethod(
+        String method,
+        dynamic Function() function, {
+        List<Object?> expectedArguments = const [],
+        dynamic expectedResult,
+      }) {
+        test('$method', () async {
+          final startCaptured = await proxy.captured(method);
+          final dynamic result = await function();
+          final captured = await proxy.captured(method);
+          expect(captured.count, startCaptured.count + 1);
+          expect(captured.invocation, isNotNull);
+
+          final positionalArguments = captured.invocation!.positionalArguments;
+          final namedArguments = captured.invocation!.namedArguments;
+          if (expectedArguments.isEmpty) {
+            expect(positionalArguments, <dynamic>[]);
+            expect(namedArguments, <dynamic, dynamic>{});
+          } else {
+            for (var i = 0; i < expectedArguments.length; i++) {
+              // Expect positional or named arguments had such argument.
+              if (i < positionalArguments.length) {
+                expect(
+                  positionalArguments[i],
+                  equals(expectedArguments[i]),
+                );
+              } else {
+                expect(
+                  namedArguments.values,
+                  contains(expectedArguments[i]),
+                  reason:
+                      "There's no such argument in invocation, or the order is incorrect",
+                );
+              }
+            }
+          }
+
+          expect(result, expectedResult);
+        });
+      }
+
+      testMethod('prepare', () => proxy.prepare());
+      testMethod(
+        'prepareFromMediaId',
+        () => proxy.prepareFromMediaId('1', Data.extras),
+        expectedArguments: ['1', Data.extras],
+      );
+      testMethod(
+        'prepareFromSearch',
+        () => proxy.prepareFromSearch(Data.query, Data.extras),
+        expectedArguments: [Data.query, Data.extras],
+      );
+      testMethod(
+        'prepareFromUri',
+        () => proxy.prepareFromUri(Data.uri, Data.extras),
+        expectedArguments: [Data.uri, Data.extras],
+      );
+      testMethod('play', () => proxy.play());
+      testMethod(
+        'playFromMediaId',
+        () => proxy.playFromMediaId(Data.mediaId, Data.extras),
+        expectedArguments: [Data.mediaId, Data.extras],
+      );
+      testMethod(
+        'playFromSearch',
+        () => proxy.playFromSearch(Data.query, Data.extras),
+        expectedArguments: [Data.query, Data.extras],
+      );
+      testMethod(
+        'playFromUri',
+        () => proxy.playFromUri(Data.uri, Data.extras),
+        expectedArguments: [Data.uri, Data.extras],
+      );
+      testMethod(
+        'playMediaItem',
+        () => proxy.playMediaItem(Data.mediaItem),
+        expectedArguments: [Data.mediaItem],
+      );
+      testMethod('pause', () => proxy.pause());
+      testMethod(
+        'click',
+        () => proxy.click(),
+        expectedArguments: [MediaButton.media],
+      );
+      testMethod('stop', () => proxy.stop());
+      testMethod(
+        'addQueueItem',
+        () => proxy.addQueueItem(Data.mediaItem),
+        expectedArguments: [Data.mediaItem],
+      );
+      testMethod(
+        'addQueueItems',
+        () => proxy.addQueueItems(Data.mediaItems),
+        expectedArguments: [Data.mediaItems],
+      );
+      testMethod(
+        'insertQueueItem',
+        () => proxy.insertQueueItem(0, Data.mediaItem),
+        expectedArguments: [0, Data.mediaItem],
+      );
+      testMethod(
+        'updateQueue',
+        () => proxy.updateQueue(Data.mediaItems),
+        expectedArguments: [Data.mediaItems],
+      );
+      testMethod(
+        'updateMediaItem',
+        () => proxy.updateMediaItem(Data.mediaItem),
+        expectedArguments: [Data.mediaItem],
+      );
+      testMethod(
+        'removeQueueItem',
+        () => proxy.removeQueueItem(Data.mediaItem),
+        expectedArguments: [Data.mediaItem],
+      );
+      testMethod(
+        'removeQueueItemAt',
+        () => proxy.removeQueueItemAt(0),
+        expectedArguments: [0],
+      );
+      testMethod('skipToNext', () => proxy.skipToNext());
+      testMethod('skipToPrevious', () => proxy.skipToPrevious());
+      testMethod('fastForward', () => proxy.fastForward());
+      testMethod('rewind', () => proxy.rewind());
+      testMethod(
+        'skipToQueueItem',
+        () => proxy.skipToQueueItem(0),
+        expectedArguments: [0],
+      );
+      testMethod(
+        'seek',
+        () => proxy.seek(Duration.zero),
+        expectedArguments: [Duration.zero],
+      );
+      testMethod(
+        'setRating',
+        () => proxy.setRating(const Rating.newHeartRating(true), Data.extras),
+        expectedArguments: [const Rating.newHeartRating(true), Data.extras],
+      );
+      testMethod(
+        'setCaptioningEnabled',
+        () => proxy.setCaptioningEnabled(true),
+        expectedArguments: [true],
+      );
+      testMethod(
+        'setRepeatMode',
+        () => proxy.setRepeatMode(AudioServiceRepeatMode.all),
+        expectedArguments: [AudioServiceRepeatMode.all],
+      );
+      testMethod(
+        'setShuffleMode',
+        () => proxy.setShuffleMode(AudioServiceShuffleMode.all),
+        expectedArguments: [AudioServiceShuffleMode.all],
+      );
+      testMethod(
+        'seekBackward',
+        () => proxy.seekBackward(true),
+        expectedArguments: [true],
+      );
+      testMethod(
+        'seekForward',
+        () => proxy.seekForward(true),
+        expectedArguments: [true],
+      );
+      testMethod(
+        'setSpeed',
+        () => proxy.setSpeed(1.5),
+        expectedArguments: [1.5],
+      );
+      testMethod('onTaskRemoved', () => proxy.onTaskRemoved());
+      testMethod('onNotificationDeleted', () => proxy.onNotificationDeleted());
+      testMethod(
+        'getChildren',
+        () => proxy.getChildren(Data.mediaId, Data.extras),
+        expectedArguments: [Data.mediaId, Data.extras],
+        expectedResult: Data.mediaItems,
+      );
+      testMethod(
+        'subscribeToChildren',
+        () => proxy.subscribeToChildren(Data.mediaId),
+        expectedArguments: [Data.mediaId],
+        expectedResult: isA<BehaviorSubject<Map<String, dynamic>>>(),
+      );
+      testMethod(
+        'getMediaItem',
+        () => proxy.getMediaItem(Data.mediaId),
+        expectedArguments: [Data.mediaId],
+        expectedResult: Data.mediaItem,
+      );
+      testMethod(
+        'search',
+        () => proxy.search(Data.query, Data.extras),
+        expectedArguments: [Data.query, Data.extras],
+        expectedResult: Data.mediaItems,
+      );
+      testMethod(
+        'androidSetRemoteVolume',
+        () => proxy.androidSetRemoteVolume(3),
+        expectedArguments: [3],
+      );
+      testMethod(
+        'androidAdjustRemoteVolume',
+        () => proxy.androidAdjustRemoteVolume(AndroidVolumeDirection.raise),
+        expectedArguments: [AndroidVolumeDirection.raise],
+      );
+      testMethod(
+        'customAction',
+        () => proxy.echo('foo'),
+        expectedArguments: [
+          'echo',
+          const {'arg': 'foo'},
+        ],
+        expectedResult: 'foo',
+      );
+    });
+
+    test('$isolateLabel stream values', () async {
+      Future<void> testStream<T>(
+          String name, ValueStream<T> stream, T value) async {
+        await proxy.add(name, value);
+        expect(stream.nvalue, value);
+      }
+
+      await testStream(
+          'playbackState', proxy.playbackState, Data.playbackState);
+      await testStream('queue', proxy.queue, Data.mediaItems);
+      await testStream('queueTitle', proxy.queueTitle, 'Queue');
+      await testStream('androidPlaybackInfo', proxy.androidPlaybackInfo,
+          Data.remotePlaybackInfo);
+      await testStream('ratingStyle', proxy.ratingStyle, RatingStyle.heart);
+      await testStream<dynamic>('customState', proxy.customState, 'foo');
+    });
+
+    test('$isolateLabel streams', () async {
+      Future<void> testStream<T>(
+          String name, Stream<T> stream, bool skipFirst, List<T> values) async {
+        final actualValues = <T>[];
+        final subscription =
+            stream.skip(skipFirst ? 1 : 0).listen(actualValues.add);
+        for (var value in values) {
+          await proxy.add(name, value);
+        }
+        expect(actualValues, values);
+        subscription.cancel();
+      }
+
+      await testStream(
+          'playbackState', proxy.playbackState, true, Data.playbackStates);
+      await testStream('queue', proxy.queue, true, [
+        Data.mediaItems,
+        Data.mediaItems
+            .map((item) =>
+                item.copyWith(displayDescription: '${item.id} description'))
+            .toList(),
+      ]);
+      await testStream('queueTitle', proxy.queueTitle, true, ['a', 'b', 'c']);
+      await testStream('mediaItem', proxy.mediaItem, true, Data.mediaItems);
+      await testStream(
+          'androidPlaybackInfo', proxy.androidPlaybackInfo, false, [
+        Data.remotePlaybackInfo,
+        LocalAndroidPlaybackInfo(),
+      ]);
+      await testStream('ratingStyle', proxy.ratingStyle, false, [
+        RatingStyle.heart,
+        RatingStyle.percentage,
+      ]);
+      await testStream<dynamic>(
+          'customEvent', proxy.customEvent, false, <dynamic>[
+        'a',
+        'b',
+        'c',
+      ]);
+      await testStream<dynamic>(
+          'customState', proxy.customState, false, <dynamic>[
+        'a',
+        'b',
+        'c',
+      ]);
+    });
+  }
 }
 
 Future<void> runIsolateHandler() async {
@@ -294,15 +383,18 @@ class _MockAudioHandler implements BaseAudioHandler {
   final BehaviorSubject<dynamic> customState = BehaviorSubject<dynamic>();
 
   final Map<String, int> invocationCounts = {};
+  final Map<String, Invocation> invocations = {};
 
   @override
   dynamic noSuchMethod(Invocation invocation) {
     final member = invocation.memberName.toString().split('"')[1];
     if (invocation.isMethod) {
       if (member != 'customAction' ||
-          invocation.positionalArguments[0] != 'count') {
-        // count invocations of everything except for 'count' itself.
+          member == 'customAction' &&
+              invocation.positionalArguments[0] != 'captured') {
+        // Count invocations of everything except for 'captured' itself.
         invocationCounts[member] = (invocationCounts[member] ?? 0) + 1;
+        invocations[member] = invocation;
       }
       switch (member) {
         case 'customAction':
@@ -326,9 +418,12 @@ class _MockAudioHandler implements BaseAudioHandler {
     final name = args[0] as String;
     final extras = args[1] as Map<String, dynamic>?;
     switch (name) {
-      case 'count':
+      case 'captured':
         final method = extras!['method'] as String;
-        return invocationCounts[method] ?? 0;
+        return _Captured(
+          invocationCounts[method] ?? 0,
+          invocations[method],
+        );
       case 'echo':
         return extras!['arg'] as String;
       case 'add':
@@ -350,16 +445,28 @@ class _MockAudioHandler implements BaseAudioHandler {
   }
 }
 
-extension AudioHandlerExtension on AudioHandler {
-  Future<int> count(String method) async =>
-      (await customAction('count', <String, dynamic>{'method': method}) as int);
+class _Captured {
+  final int count;
+  final Invocation? invocation;
 
+  _Captured(this.count, this.invocation);
+}
+
+extension AudioHandlerExtension on AudioHandler {
+  /// Gets the method invocation count and parameters.
+  Future<_Captured> captured(String method) async =>
+      (await customAction('captured', <String, dynamic>{'method': method})
+          as _Captured);
+
+  /// Returns the sent value.
   Future<String> echo(String arg) async =>
       (await customAction('echo', <String, dynamic>{'arg': arg}) as String);
 
+  /// Adds a value to a stream.
   Future<void> add(String stream, dynamic arg) =>
       customAction('add', <String, dynamic>{'stream': stream, 'arg': arg});
 
+  /// Unregisters the [IsolatedAudioHandler].
   Future<void> unregister() => customAction('unregister');
 }
 

--- a/audio_service/test/stubs.dart
+++ b/audio_service/test/stubs.dart
@@ -1,0 +1,45 @@
+import 'package:audio_service/audio_service.dart';
+
+const asciiSquare = '▮';
+
+class Data {
+  static final playbackState = PlaybackState(
+    processingState: AudioProcessingState.buffering,
+    playing: true,
+    controls: [MediaControl.pause],
+    androidCompactActionIndices: [0],
+    systemActions: {MediaAction.seek},
+    updatePosition: const Duration(seconds: 30),
+    bufferedPosition: const Duration(seconds: 35),
+    speed: 1.5,
+    updateTime: DateTime.now(),
+    errorCode: 3,
+    errorMessage: 'error message',
+    repeatMode: AudioServiceRepeatMode.all,
+    shuffleMode: AudioServiceShuffleMode.all,
+    captioningEnabled: true,
+    queueIndex: 0,
+  );
+  static final playbackStates = [
+    PlaybackState(playing: true),
+    PlaybackState(processingState: AudioProcessingState.buffering),
+    PlaybackState(speed: 1.5),
+  ];
+  static const query = 'query';
+  static final uri = Uri.parse('https://example.com/foo');
+  static const mediaId = '1';
+  static const mediaItem = MediaItem(id: '1', title: 'title1');
+  static final mediaItems = [
+    const MediaItem(id: '1', title: 'title1'),
+    const MediaItem(id: '2', title: 'title2'),
+    const MediaItem(id: '3', title: 'title3'),
+  ];
+  static const extras = <String, dynamic>{
+    'key': 'value',
+  };
+  static final remotePlaybackInfo = RemoteAndroidPlaybackInfo(
+    volumeControlType: AndroidVolumeControlType.absolute,
+    maxVolume: 10,
+    volume: 5,
+  );
+}


### PR DESCRIPTION
Added tests for invocation parameters in the `isolates_test`.

I later plan to move the `_MockAudioHandler` into a separate file and use it to test invocations from the platform interface.

Related issue https://github.com/ryanheise/audio_service/issues/716