### PR TITLE
Handle null album and artist on web

### DIFF
--- a/audio_service_web/lib/audio_service_web.dart
+++ b/audio_service_web/lib/audio_service_web.dart
@@ -147,12 +147,14 @@ class AudioServiceWeb extends AudioServicePlatform {
       return;
     }
     mediaItem = request.mediaItem;
+    final artist = mediaItem!.artist;
+    final album = mediaItem!.album;
     final artUri = mediaItem!.artUri;
 
     MediaSession.metadata = html.MediaMetadata(<String, dynamic>{
-      'album': mediaItem!.album,
       'title': mediaItem!.title,
-      'artist': mediaItem!.artist,
+      if (artist != null) 'artist': artist,
+      if (album != null) 'album': album,
       'artwork': [
         {
           'src': artUri,


### PR DESCRIPTION
With recent chrome patch the MediaMetadata seems to have started to convert `null`s to strings

![image](https://user-images.githubusercontent.com/39104740/135342584-262a2f32-4c0f-4ed2-a5e3-fd7b288c685d.png)

Handle them out

![image](https://user-images.githubusercontent.com/39104740/135342733-13774737-e0e5-4788-bebb-bd7b96fed964.png)

