### PR TITLE
[Fix] Implement fragment activity for audio service

### DIFF
--- a/audio_service/README.md
+++ b/audio_service/README.md
@@ -373,7 +373,7 @@ For more information about shrinking see [Android documentation](https://develop
 
 ### Custom Android activity
 
-`AudioService` provides the possibility to seamlessly integrate to either `Activity` or `Fragment` you're using as your main class.  
+`AudioService` provides the possibility to seamlessly integrate to either `Activity` or `FragmentActivity` you're using as your main class.  
 If you choose to use this way, make sure you update `AndroidManifest.xml` to match the name of this activity (assuming it's called `MainActivity`) instead of `com.ryanheise.audioservice.AudioServiceActivity`.
 ```xml
 <activity android:name=".MainActivity" ...>
@@ -386,7 +386,7 @@ import com.ryanheise.audioservice.AudioServiceActivity;
 public class MainActivity extends AudioServiceActivity {}
 ```
 
-2. Integration as a `Fragment`
+2. Integration as a `FragmentActivity`
 ```java
 import com.ryanheise.audioservice.AudioServiceFragmentActivity;
 

--- a/audio_service/README.md
+++ b/audio_service/README.md
@@ -373,18 +373,27 @@ For more information about shrinking see [Android documentation](https://develop
 
 ### Custom Android activity
 
-If your app uses a custom activity, you will need to override `provideFlutterEngine` as follows to ensure that your activity and service use the same shared Flutter engine:
-
-```java
-public class CustomActivity extends FlutterActivity {
-  @Override
-  public FlutterEngine provideFlutterEngine(Context context) {
-    return AudioServicePlugin.getFlutterEngine(context);
-  }
-}
+`AudioService` provides the possibility to seamlessly integrate to either `Activity` or `Fragment` you're using as your main class.  
+If you choose to use this way, make sure you update `AndroidManifest.xml` to match the name of this activity (assuming it's called `MainActivity`) instead of `com.ryanheise.audioservice.AudioServiceActivity`.
+```xml
+<activity android:name=".MainActivity" ...>
 ```
 
-Alternatively, you can make your custom activity a subclass of `AudioServiceActivity` and thereby inherit its implementation of `provideFlutterEngine`.
+1. Integration as an `Activity`
+```java
+import com.ryanheise.audioservice.AudioServiceActivity;
+
+public class MainActivity extends AudioServiceActivity {}
+```
+
+2. Integration as a `Fragment`
+```java
+import com.ryanheise.audioservice.AudioServiceFragmentActivity;
+
+public class MainActivity extends AudioServiceFragmentActivity {}
+```
+
+Alternatively, you can make your custom activity a subclass of `FlutterActivity` or `FlutterFragmentActivity` and implement your own engine. Inspiration for the implementation can be taken from `AudioServiceActivity.java` or `AudioServiceFragmentActivity.java`.
 
 ## iOS setup
 

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServiceFragmentActivity.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServiceFragmentActivity.java
@@ -4,12 +4,17 @@ import android.content.Context;
 
 import androidx.annotation.NonNull;
 
-import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.android.FlutterFragmentActivity;
 import io.flutter.embedding.engine.FlutterEngine;
 
-public class AudioServiceActivity extends FlutterActivity {
+public class AudioServiceFragmentActivity extends FlutterFragmentActivity {
     @Override
     public FlutterEngine provideFlutterEngine(@NonNull Context context) {
         return AudioServicePlugin.getFlutterEngine(context);
+    }
+
+    protected String getCachedEngineId() {
+        AudioServicePlugin.getFlutterEngine(this);
+        return AudioServicePlugin.getFlutterEngineId();
     }
 }

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServiceFragmentActivity.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServiceFragmentActivity.java
@@ -13,8 +13,14 @@ public class AudioServiceFragmentActivity extends FlutterFragmentActivity {
         return AudioServicePlugin.getFlutterEngine(context);
     }
 
+    @Override
     protected String getCachedEngineId() {
         AudioServicePlugin.getFlutterEngine(this);
         return AudioServicePlugin.getFlutterEngineId();
+    }
+
+    @Override
+    public boolean shouldDestroyEngineWithHost() {
+        return false;
     }
 }

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServiceFragmentActivity.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServiceFragmentActivity.java
@@ -19,6 +19,8 @@ public class AudioServiceFragmentActivity extends FlutterFragmentActivity {
         return AudioServicePlugin.getFlutterEngineId();
     }
 
+    // The engine is created and managed by AudioServicePlugin,
+    // it should not be destroyed with the activity.
     @Override
     public boolean shouldDestroyEngineWithHost() {
         return false;


### PR DESCRIPTION
About
--
[Original issue](https://github.com/ryanheise/audio_service/issues/839).


HOLDing this PR for now. I will test more in following weeks to make sure this fix working as intended and I'm not experiencing `Flutter JNI` crash anymore.
Furthermore - if all good, I will also need to update README for different initialisation if one is running `FragmentActivity`.

Also, if someone will be facing this `Flutter JNI` issue - they can try using this PR to make sure majority (all?) crashes went away.


Work
--
- [x] Implement `AudioServiceFragmentActivity`
- [x] Cleanup `AudioServiceActivity` for unused imports
- [x] Update README 
