### PR TITLE
Add ArtContentProvider

### DIFF
--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/ArtContentProvider.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/ArtContentProvider.java
@@ -1,0 +1,175 @@
+package com.ryanheise.audioservice;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.CancellationSignal;
+import android.os.ParcelFileDescriptor;
+import android.util.Log;
+import android.util.SparseArray;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import io.flutter.plugin.common.MethodChannel;
+
+public class ArtContentProvider extends ContentProvider {
+    @Override
+    public boolean onCreate() {
+        return true;
+    }
+
+    private ExecutorService executorService = Executors.newCachedThreadPool();
+
+    private int id = 0;
+    private synchronized int getRequestId() {
+        final int requestId = id;
+        id++;
+        if (id > 100000) {
+            id = 0;
+        }
+        return requestId;
+    }
+
+    private static final SparseArray<MethodChannel.Result> results = new SparseArray<>();
+
+    /**
+     * Successfully end art path request task.
+     */
+    static void successPathRequest(int requestId, String path) {
+        synchronized (results) {
+            Log.w("ArtContentProvider", "success " + requestId);
+            MethodChannel.Result result = results.get(requestId);
+            result.success(path);
+        }
+    }
+
+    /**
+     * End art path request task with null path due to error.
+     */
+    static void terminatePathRequest(int requestId) {
+        synchronized (results) {
+            Log.w("ArtContentProvider", "error " + requestId);
+            MethodChannel.Result result = results.get(requestId);
+            result.error(null, null, null);
+        }
+    }
+
+    class Task implements Callable<String> {
+        Task(Uri uri) {
+            this.uri = uri;
+        }
+
+        Uri uri;
+        String path;
+        boolean responded = false;
+
+        @Override
+        public String call() throws Exception {
+            final int requestId = getRequestId();
+            Log.w("ArtContentProvider", "start " + requestId);
+            MethodChannel.Result result = new MethodChannel.Result() {
+                void end() {
+                    responded = true;
+                    synchronized (Task.this) {
+                        Task.this.notify();
+                    }
+                }
+
+                @Override
+                public void success(@Nullable Object result) {
+                    path = (String) result;
+                    results.remove(requestId);
+                    end();
+                }
+
+                @Override
+                public void error(String errorCode, @Nullable String errorMessage, @Nullable Object errorDetails) {
+                    end();
+                }
+
+                @Override
+                public void notImplemented() {
+                    end();
+                }
+            };
+
+            synchronized (results) {
+                results.put(requestId, result);
+            }
+
+            AudioServicePlugin.getArtFilePath(requestId, uri);
+
+            synchronized (Task.this) {
+                while (!responded) {
+                    Task.this.wait();
+                }
+            }
+            return path;
+        }
+    }
+
+    @Nullable
+    @Override
+    public ParcelFileDescriptor openFile(@NonNull Uri uri, @NonNull String mode) throws FileNotFoundException {
+        Task task = new Task(uri);
+        Future<String> future = executorService.submit(task);
+//        cancellationSignal.setOnCancelListener(() -> {
+//            task.lock.notify();
+//        });
+        String path = null;
+        try {
+            path = future.get();
+        } catch (ExecutionException e) {
+            e.printStackTrace();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        File file;
+        if (path != null) {
+            file = new File(path);
+        } else {
+            throw new FileNotFoundException(path);
+        }
+        return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY);
+    }
+
+    @Nullable
+    @Override
+    public Cursor query(@NonNull Uri uri, @Nullable String[] projection, @Nullable String selection, @Nullable String[] selectionArgs, @Nullable String sortOrder) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getType(@NonNull Uri uri) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Uri insert(@NonNull Uri uri, @Nullable ContentValues values) {
+        return null;
+    }
+
+    @Override
+    public int delete(@NonNull Uri uri, @Nullable String selection, @Nullable String[] selectionArgs) {
+        return 0;
+    }
+
+    @Override
+    public int update(@NonNull Uri uri, @Nullable ContentValues values, @Nullable String selection, @Nullable String[] selectionArgs) {
+        return 0;
+    }
+}

--- a/audio_service/example/android/app/src/main/AndroidManifest.xml
+++ b/audio_service/example/android/app/src/main/AndroidManifest.xml
@@ -43,8 +43,20 @@
         </receiver> 
 
         <meta-data
+            android:name="com.google.android.gms.car.application"
+            android:resource="@xml/automotive_app_desc"/>
+
+        <meta-data android:name="com.google.android.gms.car.notification.SmallIcon"
+                   android:resource="@mipmap/ic_launcher" />
+
+        <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+
+        <provider
+            android:name="com.ryanheise.audioservice.ArtContentProvider"
+            android:authorities="com.ryanheise.audioservice"
+            android:exported="true" />
 
     </application>
 </manifest>

--- a/audio_service/example/android/app/src/main/res/xml/automotive_app_desc.xml
+++ b/audio_service/example/android/app/src/main/res/xml/automotive_app_desc.xml
@@ -1,0 +1,3 @@
+<automotiveApp>
+   <uses name="media" />
+</automotiveApp>

--- a/audio_service/example/lib/main.dart
+++ b/audio_service/example/lib/main.dart
@@ -1,28 +1,27 @@
 // ignore_for_file: public_member_api_docs
 
-// FOR MORE EXAMPLES, VISIT THE GITHUB REPOSITORY AT:
+// This example demonstrates:
 //
-//  https://github.com/ryanheise/audio_service
-//
-// This example implements a minimal audio handler that renders the current
-// media item and playback state to the system notification and responds to 4
-// media actions:
-//
-// - play
-// - pause
-// - seek
-// - stop
+// - queues/playlists
+// - switching between audio handlers (audio player / text-to-speech player)
+// - logging
+// - custom actions
+// - custom events
+// - Android 11 media session resumption
+// - Android Auto
 //
 // To run this example, use:
 //
-// flutter run
+// flutter run -t lib/example_multiple_handlers.dart
 
 import 'dart:async';
 
 import 'package:audio_service/audio_service.dart';
 import 'package:audio_service_example/common.dart';
+import 'package:audio_session/audio_session.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_tts/flutter_tts.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -30,9 +29,21 @@ import 'package:rxdart/rxdart.dart';
 // global variable.
 late AudioHandler _audioHandler;
 
+/// Extension methods for our custom actions.
+extension DemoAudioHandler on AudioHandler {
+  Future<void> switchToHandler(int? index) async {
+    if (index == null) return;
+    await _audioHandler
+        .customAction('switchToHandler', <String, dynamic>{'index': index});
+  }
+}
+
 Future<void> main() async {
   _audioHandler = await AudioService.init(
-    builder: () => AudioPlayerHandler(),
+    builder: () => LoggingAudioHandler(MainSwitchHandler([
+      AudioPlayerHandler(),
+      TextPlayerHandler(),
+    ])),
     config: const AudioServiceConfig(
       androidNotificationChannelId: 'com.ryanheise.myapp.channel.audio',
       androidNotificationChannelName: 'Audio playback',
@@ -42,6 +53,7 @@ Future<void> main() async {
   runApp(MyApp());
 }
 
+/// The app widget
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -53,7 +65,13 @@ class MyApp extends StatelessWidget {
   }
 }
 
+/// The main screen.
 class MainScreen extends StatelessWidget {
+  static const _handlerNames = [
+    'Audio Player',
+    'Text-To-Speech',
+  ];
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -64,12 +82,57 @@ class MainScreen extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            // Show media item title
-            StreamBuilder<MediaItem?>(
-              stream: _audioHandler.mediaItem,
+            // Queue display/controls.
+            StreamBuilder<QueueState>(
+              stream: _queueStateStream,
               builder: (context, snapshot) {
-                final mediaItem = snapshot.data;
-                return Text(mediaItem?.title ?? '');
+                final queueState = snapshot.data;
+                final queue = queueState?.queue ?? const [];
+                final mediaItem = queueState?.mediaItem;
+                return Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    StreamBuilder<dynamic>(
+                      stream: _audioHandler.customState,
+                      builder: (context, snapshot) {
+                        final handlerIndex =
+                            (snapshot.data?.handlerIndex as int?) ?? 0;
+                        return DropdownButton<int>(
+                          value: handlerIndex,
+                          items: [
+                            for (var i = 0; i < _handlerNames.length; i++)
+                              DropdownMenuItem<int>(
+                                value: i,
+                                child: Text(_handlerNames[i]),
+                              ),
+                          ],
+                          onChanged: _audioHandler.switchToHandler,
+                        );
+                      },
+                    ),
+                    if (queue.isNotEmpty)
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          IconButton(
+                            icon: const Icon(Icons.skip_previous),
+                            iconSize: 64.0,
+                            onPressed: mediaItem == queue.first
+                                ? null
+                                : _audioHandler.skipToPrevious,
+                          ),
+                          IconButton(
+                            icon: const Icon(Icons.skip_next),
+                            iconSize: 64.0,
+                            onPressed: mediaItem == queue.last
+                                ? null
+                                : _audioHandler.skipToNext,
+                          ),
+                        ],
+                      ),
+                    if (mediaItem?.title != null) Text(mediaItem!.title),
+                  ],
+                );
               },
             ),
             // Play/pause/stop buttons.
@@ -82,13 +145,8 @@ class MainScreen extends StatelessWidget {
                 return Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    _button(Icons.fast_rewind, _audioHandler.rewind),
-                    if (playing)
-                      _button(Icons.pause, _audioHandler.pause)
-                    else
-                      _button(Icons.play_arrow, _audioHandler.play),
-                    _button(Icons.stop, _audioHandler.stop),
-                    _button(Icons.fast_forward, _audioHandler.fastForward),
+                    if (playing) _pauseButton() else _playButton(),
+                    _stopButton(),
                   ],
                 );
               },
@@ -119,6 +177,22 @@ class MainScreen extends StatelessWidget {
                     "Processing state: ${describeEnum(processingState)}");
               },
             ),
+            // Display the latest custom event.
+            StreamBuilder<dynamic>(
+              stream: _audioHandler.customEvent,
+              builder: (context, snapshot) {
+                return Text("custom event: ${snapshot.data}");
+              },
+            ),
+            // Display the notification click status.
+            StreamBuilder<bool>(
+              stream: AudioService.notificationClicked,
+              builder: (context, snapshot) {
+                return Text(
+                  'Notification Click Status: ${snapshot.data}',
+                );
+              },
+            ),
           ],
         ),
       ),
@@ -133,11 +207,38 @@ class MainScreen extends StatelessWidget {
           AudioService.position,
           (mediaItem, position) => MediaState(mediaItem, position));
 
-  IconButton _button(IconData iconData, VoidCallback onPressed) => IconButton(
-        icon: Icon(iconData),
+  /// A stream reporting the combined state of the current queue and the current
+  /// media item within that queue.
+  Stream<QueueState> get _queueStateStream =>
+      Rx.combineLatest2<List<MediaItem>, MediaItem?, QueueState>(
+          _audioHandler.queue,
+          _audioHandler.mediaItem,
+          (queue, mediaItem) => QueueState(queue, mediaItem));
+
+  IconButton _playButton() => IconButton(
+        icon: const Icon(Icons.play_arrow),
         iconSize: 64.0,
-        onPressed: onPressed,
+        onPressed: _audioHandler.play,
       );
+
+  IconButton _pauseButton() => IconButton(
+        icon: const Icon(Icons.pause),
+        iconSize: 64.0,
+        onPressed: _audioHandler.pause,
+      );
+
+  IconButton _stopButton() => IconButton(
+        icon: const Icon(Icons.stop),
+        iconSize: 64.0,
+        onPressed: _audioHandler.stop,
+      );
+}
+
+class QueueState {
+  final List<MediaItem> queue;
+  final MediaItem? mediaItem;
+
+  QueueState(this.queue, this.mediaItem);
 }
 
 class MediaState {
@@ -147,37 +248,132 @@ class MediaState {
   MediaState(this.mediaItem, this.position);
 }
 
-/// An [AudioHandler] for playing a single item.
-class AudioPlayerHandler extends BaseAudioHandler with SeekHandler {
-  static final _item = MediaItem(
-    id: 'https://s3.amazonaws.com/scifri-episodes/scifri20181123-episode.mp3',
-    album: "Science Friday",
-    title: "A Salute To Head-Scratching Science",
-    artist: "Science Friday and WNYC Studios",
-    duration: const Duration(milliseconds: 5739820),
-    artUri: Uri.parse(
-        'https://media.wnyc.org/i/1400/1400/l/80/1/ScienceFriday_WNYCStudios_1400.jpg'),
-  );
+class CustomEvent {
+  final int handlerIndex;
 
-  final _player = AudioPlayer();
+  CustomEvent(this.handlerIndex);
+}
 
-  /// Initialise our audio handler.
-  AudioPlayerHandler() {
-    // So that our clients (the Flutter UI and the system notification) know
-    // what state to display, here we set up our audio handler to broadcast all
-    // playback state changes as they happen via playbackState...
-    _player.playbackEventStream.map(_transformEvent).pipe(playbackState);
-    // ... and also the current media item via mediaItem.
-    mediaItem.add(_item);
+class MainSwitchHandler extends SwitchAudioHandler {
+  final List<AudioHandler> handlers;
+  @override
+  BehaviorSubject<dynamic> customState =
+      BehaviorSubject<dynamic>.seeded(CustomEvent(0));
 
-    // Load the player.
-    _player.setAudioSource(AudioSource.uri(Uri.parse(_item.id)));
+  MainSwitchHandler(this.handlers) : super(handlers.first) {
+    // Configure the app's audio category and attributes for speech.
+    AudioSession.instance.then((session) {
+      session.configure(const AudioSessionConfiguration.speech());
+    });
   }
 
-  // In this simple example, we handle only 4 actions: play, pause, seek and
-  // stop. Any button press from the Flutter UI, notification, lock screen or
-  // headset will be routed through to these 4 methods so that you can handle
-  // your audio playback logic in one place.
+  @override
+  Future<dynamic> customAction(String name,
+      [Map<String, dynamic>? extras]) async {
+    switch (name) {
+      case 'switchToHandler':
+        stop();
+        final index = extras!['index'] as int;
+        inner = handlers[index];
+        customState.add(CustomEvent(index));
+        return null;
+      default:
+        return super.customAction(name, extras);
+    }
+  }
+}
+
+/// An [AudioHandler] for playing a list of podcast episodes.
+class AudioPlayerHandler extends BaseAudioHandler
+    with QueueHandler, SeekHandler {
+  // ignore: close_sinks
+  final BehaviorSubject<List<MediaItem>> _recentSubject =
+      BehaviorSubject.seeded(<MediaItem>[]);
+  final _mediaLibrary = MediaLibrary();
+  final _player = AudioPlayer();
+
+  int? get index => _player.currentIndex;
+
+  AudioPlayerHandler() {
+    _init();
+  }
+
+  Future<void> _init() async {
+    // Load and broadcast the queue
+    queue.add(_mediaLibrary.items[MediaLibrary.albumsRootId]!);
+    // For Android 11, record the most recent item so it can be resumed.
+    mediaItem
+        .whereType<MediaItem>()
+        .listen((item) => _recentSubject.add([item]));
+    // Broadcast media item changes.
+    _player.currentIndexStream.listen((index) {
+      if (index != null) mediaItem.add(queue.value[index]);
+    });
+    // Propagate all events from the audio player to AudioService clients.
+    _player.playbackEventStream.listen(_broadcastState);
+    // In this example, the service stops when reaching the end.
+    _player.processingStateStream.listen((state) {
+      if (state == ProcessingState.completed) stop();
+    });
+    try {
+      // After a cold restart (on Android), _player.load jumps straight from
+      // the loading state to the completed state. Inserting a delay makes it
+      // work. Not sure why!
+      //await Future.delayed(Duration(seconds: 2)); // magic delay
+      await _player.setAudioSource(ConcatenatingAudioSource(
+        children: queue.value
+            .map((item) => AudioSource.uri(Uri.parse(item.id)))
+            .toList(),
+      ));
+    } catch (e) {
+      print("Error: $e");
+    }
+  }
+
+  @override
+  Future<List<MediaItem>> getChildren(String parentMediaId,
+      [Map<String, dynamic>? options]) async {
+    switch (parentMediaId) {
+      case AudioService.recentRootId:
+        // When the user resumes a media session, tell the system what the most
+        // recently played item was.
+        return _recentSubject.value;
+      default:
+        // Allow client to browse the media library.
+        return _mediaLibrary.items[parentMediaId]!;
+    }
+  }
+
+  @override
+  ValueStream<Map<String, dynamic>> subscribeToChildren(String parentMediaId) {
+    switch (parentMediaId) {
+      case AudioService.recentRootId:
+        final stream = _recentSubject.map((_) => <String, dynamic>{});
+        return _recentSubject.hasValue
+            ? stream.shareValueSeeded(<String, dynamic>{})
+            : stream.shareValue();
+      default:
+        return Stream.value(_mediaLibrary.items[parentMediaId])
+            .map((_) => <String, dynamic>{})
+            .shareValue();
+    }
+  }
+
+  @override
+  Future<List<MediaItem>> search(String query, [Map<String, dynamic>? extras]) async {
+    return _mediaLibrary.items[MediaLibrary.albumsRootId]!;
+  }
+
+  @override
+  Future<void> skipToQueueItem(int index) async {
+    // Then default implementations of skipToNext and skipToPrevious provided by
+    // the [QueueHandler] mixin will delegate to this method.
+    if (index < 0 || index >= queue.value.length) return;
+    // This jumps to the beginning of the queue item at newIndex.
+    _player.seek(Duration.zero, index: index);
+    // Demonstrate custom events.
+    customEvent.add('skip to $index');
+  }
 
   @override
   Future<void> play() => _player.play();
@@ -189,20 +385,21 @@ class AudioPlayerHandler extends BaseAudioHandler with SeekHandler {
   Future<void> seek(Duration position) => _player.seek(position);
 
   @override
-  Future<void> stop() => _player.stop();
+  Future<void> stop() async {
+    await _player.stop();
+    await playbackState.firstWhere(
+        (state) => state.processingState == AudioProcessingState.idle);
+  }
 
-  /// Transform a just_audio event into an audio_service state.
-  ///
-  /// This method is used from the constructor. Every event received from the
-  /// just_audio player will be transformed into an audio_service state so that
-  /// it can be broadcast to audio_service clients.
-  PlaybackState _transformEvent(PlaybackEvent event) {
-    return PlaybackState(
+  /// Broadcasts the current state to all clients.
+  void _broadcastState(PlaybackEvent event) {
+    final playing = _player.playing;
+    playbackState.add(playbackState.value.copyWith(
       controls: [
-        MediaControl.rewind,
-        if (_player.playing) MediaControl.pause else MediaControl.play,
+        MediaControl.skipToPrevious,
+        if (playing) MediaControl.pause else MediaControl.play,
         MediaControl.stop,
-        MediaControl.fastForward,
+        MediaControl.skipToNext,
       ],
       systemActions: const {
         MediaAction.seek,
@@ -217,11 +414,290 @@ class AudioPlayerHandler extends BaseAudioHandler with SeekHandler {
         ProcessingState.ready: AudioProcessingState.ready,
         ProcessingState.completed: AudioProcessingState.completed,
       }[_player.processingState]!,
-      playing: _player.playing,
+      playing: playing,
       updatePosition: _player.position,
       bufferedPosition: _player.bufferedPosition,
       speed: _player.speed,
       queueIndex: event.currentIndex,
-    );
+    ));
   }
 }
+
+/// Provides access to a library of media items. In your app, this could come
+/// from a database or web service.
+class MediaLibrary {
+  static const albumsRootId = 'albums';
+
+  final items = <String, List<MediaItem>>{
+    AudioService.browsableRootId: const [
+      MediaItem(
+        id: albumsRootId,
+        title: "Albums",
+        playable: false,
+      ),
+    ],
+    albumsRootId: [
+      MediaItem(
+        id: 'https://s3.amazonaws.com/scifri-episodes/scifri20181123-episode.mp3',
+        album: "Science Friday",
+        title: "A Salute To Head-Scratching Science",
+        artist: "Science Friday and WNYC Studios",
+        duration: const Duration(milliseconds: 5739820),
+        artUri: Uri.parse(
+            'https://media.wnyc.org/i/1400/1400/l/80/1/ScienceFriday_WNYCStudios_1400.jpg'),
+      ),
+      MediaItem(
+        id: 'https://s3.amazonaws.com/scifri-segments/scifri201711241.mp3',
+        album: "Science Friday",
+        title: "From Cat Rheology To Operatic Incompetence",
+        artist: "Science Friday and WNYC Studios",
+        duration: const Duration(milliseconds: 2856950),
+        artUri: Uri.parse(
+            'https://media.wnyc.org/i/1400/1400/l/80/1/ScienceFriday_WNYCStudios_1400.jpg'),
+      ),
+          for (int i = 500; i < 1000; i++)
+      MediaItem(
+        id: '$i',
+        album: '$i',
+        title: '$i',
+        artUri: Uri.parse("https://picsum.photos/900/900?random=$i"),
+      ),
+    ],
+  };
+}
+
+/// This task defines logic for speaking a sequence of numbers using
+/// text-to-speech.
+class TextPlayerHandler extends BaseAudioHandler with QueueHandler {
+  final _tts = Tts();
+  final _sleeper = Sleeper();
+  Completer<void>? _completer;
+  var _index = 0;
+  bool _interrupted = false;
+  var _running = false;
+
+  bool get _playing => playbackState.value.playing;
+
+  TextPlayerHandler() {
+    _init();
+  }
+
+  Future<void> _init() async {
+    final session = await AudioSession.instance;
+    // Handle audio interruptions.
+    session.interruptionEventStream.listen((event) {
+      if (event.begin) {
+        if (_playing) {
+          pause();
+          _interrupted = true;
+        }
+      } else {
+        switch (event.type) {
+          case AudioInterruptionType.pause:
+          case AudioInterruptionType.duck:
+            if (!_playing && _interrupted) {
+              play();
+            }
+            break;
+          case AudioInterruptionType.unknown:
+            break;
+        }
+        _interrupted = false;
+      }
+    });
+    // Handle unplugged headphones.
+    session.becomingNoisyEventStream.listen((_) {
+      if (_playing) pause();
+    });
+    queue.add(List.generate(
+        10,
+        (i) => MediaItem(
+              id: 'tts_${i + 1}',
+              album: 'Numbers',
+              title: 'Number ${i + 1}',
+              artist: 'Sample Artist',
+              extras: <String, int>{'number': i + 1},
+              duration: const Duration(seconds: 1),
+            )));
+  }
+
+  Future<void> run() async {
+    _completer = Completer<void>();
+    _running = true;
+    while (_running) {
+      try {
+        if (_playing) {
+          mediaItem.add(queue.value[_index]);
+          playbackState.add(playbackState.value.copyWith(
+            updatePosition: Duration.zero,
+            queueIndex: _index,
+          ));
+          AudioService.androidForceEnableMediaButtons();
+          await Future.wait([
+            _tts.speak('${mediaItem.value!.extras!["number"]}'),
+            _sleeper.sleep(const Duration(seconds: 1)),
+          ]);
+          if (_index + 1 < queue.value.length) {
+            _index++;
+          } else {
+            _running = false;
+          }
+        } else {
+          await _sleeper.sleep();
+        }
+        // ignore: empty_catches
+      } on SleeperInterruptedException {
+        // ignore: empty_catches
+      } on TtsInterruptedException {}
+    }
+    _index = 0;
+    mediaItem.add(queue.value[_index]);
+    playbackState.add(playbackState.value.copyWith(
+      updatePosition: Duration.zero,
+    ));
+    if (playbackState.value.processingState != AudioProcessingState.idle) {
+      stop();
+    }
+    _completer?.complete();
+    _completer = null;
+  }
+
+  @override
+  Future<void> skipToQueueItem(int index) async {
+    _index = index;
+    _signal();
+  }
+
+  @override
+  Future<void> play() async {
+    if (_playing) return;
+    final session = await AudioSession.instance;
+    // flutter_tts doesn't activate the session, so we do it here. This
+    // allows the app to stop other apps from playing audio while we are
+    // playing audio.
+    if (await session.setActive(true)) {
+      // If we successfully activated the session, set the state to playing
+      // and resume playback.
+      playbackState.add(playbackState.value.copyWith(
+        controls: [MediaControl.pause, MediaControl.stop],
+        processingState: AudioProcessingState.ready,
+        playing: true,
+      ));
+      if (_completer == null) {
+        run();
+      } else {
+        _sleeper.interrupt();
+      }
+    }
+  }
+
+  @override
+  Future<void> pause() async {
+    _interrupted = false;
+    playbackState.add(playbackState.value.copyWith(
+      controls: [MediaControl.play, MediaControl.stop],
+      processingState: AudioProcessingState.ready,
+      playing: false,
+    ));
+    _signal();
+  }
+
+  @override
+  Future<void> stop() async {
+    playbackState.add(playbackState.value.copyWith(
+      controls: [],
+      processingState: AudioProcessingState.idle,
+      playing: false,
+    ));
+    _running = false;
+    _signal();
+    // Wait for the speech to stop
+    await _completer?.future;
+    // Shut down this task
+    await super.stop();
+  }
+
+  void _signal() {
+    _sleeper.interrupt();
+    _tts.interrupt();
+  }
+}
+
+/// An object that performs interruptable sleep.
+class Sleeper {
+  Completer<void>? _blockingCompleter;
+
+  /// Sleep for a duration. If sleep is interrupted, a
+  /// [SleeperInterruptedException] will be thrown.
+  Future<void> sleep([Duration? duration]) async {
+    _blockingCompleter = Completer();
+    if (duration != null) {
+      await Future.any<void>(
+          [Future.delayed(duration), _blockingCompleter!.future]);
+    } else {
+      await _blockingCompleter!.future;
+    }
+    final interrupted = _blockingCompleter!.isCompleted;
+    _blockingCompleter = null;
+    if (interrupted) {
+      throw SleeperInterruptedException();
+    }
+  }
+
+  /// Interrupt any sleep that's underway.
+  void interrupt() {
+    if (_blockingCompleter?.isCompleted == false) {
+      _blockingCompleter!.complete();
+    }
+  }
+}
+
+class SleeperInterruptedException {}
+
+/// A wrapper around FlutterTts that makes it easier to wait for speech to
+/// complete.
+class Tts {
+  final FlutterTts _flutterTts = FlutterTts();
+  Completer<void>? _speechCompleter;
+  bool _interruptRequested = false;
+  bool _playing = false;
+
+  Tts() {
+    _flutterTts.setCompletionHandler(() {
+      _speechCompleter?.complete();
+    });
+  }
+
+  bool get playing => _playing;
+
+  Future<void> speak(String text) async {
+    _playing = true;
+    if (!_interruptRequested) {
+      _speechCompleter = Completer();
+      await _flutterTts.speak(text);
+      await _speechCompleter!.future;
+      _speechCompleter = null;
+    }
+    _playing = false;
+    if (_interruptRequested) {
+      _interruptRequested = false;
+      throw TtsInterruptedException();
+    }
+  }
+
+  Future<void> stop() async {
+    if (_playing) {
+      await _flutterTts.stop();
+      _speechCompleter?.complete();
+    }
+  }
+
+  void interrupt() {
+    if (_playing) {
+      _interruptRequested = true;
+      stop();
+    }
+  }
+}
+
+class TtsInterruptedException {}

--- a/audio_service/pubspec.yaml
+++ b/audio_service/pubspec.yaml
@@ -9,10 +9,10 @@ environment:
 
 dependencies:
   # Use these deps for local development
-  # audio_service_platform_interface:
-  #   path: ../audio_service_platform_interface
-  # audio_service_web:
-  #   path: ../audio_service_web
+  audio_service_platform_interface:
+    path: ../audio_service_platform_interface
+  audio_service_web:
+    path: ../audio_service_web
 
   # Use these deps when pushing to origin (for the benefit of testers)
   # audio_service_platform_interface:
@@ -27,8 +27,8 @@ dependencies:
   #     path: audio_service_web
 
   # Use these deps when publishing.
-  audio_service_platform_interface: ^0.1.0
-  audio_service_web: ^0.1.1
+  # audio_service_platform_interface: ^0.1.0
+  # audio_service_web: ^0.1.0
 
   audio_session: ^0.1.6+1
   rxdart: '>=0.26.0 <0.28.0'

--- a/audio_service_platform_interface/lib/audio_service_platform_interface.dart
+++ b/audio_service_platform_interface/lib/audio_service_platform_interface.dart
@@ -73,9 +73,23 @@ abstract class AudioServicePlatform extends PlatformInterface {
         'notifyChildrenChanged() has not been implemented.');
   }
 
+  void sendArtPath(int requestId, String? path) {
+    throw UnimplementedError('sendArtPath() has not been implemented.');
+  }
+
+  void setClientCallbacks(ClientCallbacks callbacks) {
+    throw UnimplementedError('setClientCallbacks() has not been implemented.');
+  }
+
   void setHandlerCallbacks(AudioHandlerCallbacks callbacks) {
     throw UnimplementedError('setHandlerCallbacks() has not been implemented.');
   }
+}
+
+/// Callbacks from platform client to the plugin.
+abstract class ClientCallbacks {
+  /// Return the art file path based on it's content uri.
+  Future<String?> getArtFilePath(int requestId, Uri uri);
 }
 
 /// Callbacks from the platform to the handler.

--- a/audio_service_web/pubspec.yaml
+++ b/audio_service_web/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 
 dependencies:
   # Use these deps for local development
-  # audio_service_platform_interface:
-  #   path: ../audio_service_platform_interface
+  audio_service_platform_interface:
+    path: ../audio_service_platform_interface
 
   # Use these deps when pushing to origin (for the benefit of testers)
   # audio_service_platform_interface:
@@ -20,7 +20,7 @@ dependencies:
   #     path: audio_service_platform_interface
 
   # Use these deps when publishing.
-  audio_service_platform_interface: ^0.1.0
+  # audio_service_platform_interface: ^0.1.0
 
   rxdart: '>=0.26.0 <0.28.0'
   js: ^0.6.3


### PR DESCRIPTION
This adds a ContentProvider implementation for album arts, which exposes cached album art file descriptors to other apps.

Related issue https://github.com/ryanheise/audio_service/issues/784

This PR also contains unrelated changes to the `example` and `pubspec`s to make it easy to test.

<details>
<summary>Video of example in Android Auto</summary>

https://user-images.githubusercontent.com/39104740/137988815-1c1fb892-71da-42cc-8b31-9df33b1a048f.mp4

</details> 