### PR TITLE
feat: reconfigure AudioService after init

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Migrate to flutter_lints.
 * Queue messages from platform if init() called late.
 * Fix deep linking on Android (@vishna/@ryanheise).
+* Allow configuration to be updated after init (@ddfreiling).
 
 ## 0.18.1
 

--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,10 +1,13 @@
+## 0.18.3
+
+* Allow configuration to be updated after init (@ddfreiling).
+
 ## 0.18.2
 
 * Guard against NPE when Android service is destroyed quickly.
 * Migrate to flutter_lints.
 * Queue messages from platform if init() called late.
 * Fix deep linking on Android (@vishna/@ryanheise).
-* Allow configuration to be updated after init (@ddfreiling).
 
 ## 0.18.1
 

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -343,6 +343,8 @@ public class AudioService extends MediaBrowserServiceCompat {
         if (!config.androidResumeOnClick) {
             mediaSession.setMediaButtonReceiver(null);
         }
+        // This might be a re-configuration, so the notification should be rebuilt (if created).
+        updateNotification();
     }
 
     int getResourceId(String resource) {

--- a/audio_service/darwin/Classes/AudioServicePlugin.m
+++ b/audio_service/darwin/Classes/AudioServicePlugin.m
@@ -141,6 +141,11 @@ static NSMutableDictionary *nowPlayingInfo = nil;
         NSDictionary *configMap = (NSDictionary *)args[@"config"];
         fastForwardInterval = configMap[@"fastForwardInterval"];
         rewindInterval = configMap[@"rewindInterval"];
+        if (_controlsUpdated) {
+            // Remote controls should be updated again on re-configuration.
+            _controlsUpdated = NO;
+            [self updateControls];
+        }
         result(@{});
     } else if ([@"setState" isEqualToString:call.method]) {
         NSDictionary *args = (NSDictionary *)call.arguments;

--- a/audio_service/example/lib/main.dart
+++ b/audio_service/example/lib/main.dart
@@ -36,7 +36,8 @@ Future<void> main() async {
     config: const AudioServiceConfig(
       androidNotificationChannelId: 'com.ryanheise.myapp.channel.audio',
       androidNotificationChannelName: 'Audio playback',
-      androidNotificationOngoing: true,
+      rewindInterval: Duration(seconds: 15),
+      fastForwardInterval: Duration(seconds: 15),
     ),
   );
   runApp(const MyApp());
@@ -57,6 +58,19 @@ class MyApp extends StatelessWidget {
 
 class MainScreen extends StatelessWidget {
   const MainScreen({Key? key}) : super(key: key);
+
+  void _updateConfig() {
+    // Switch between 15 and 60 second intervals.
+    final newInterval = AudioService.config.rewindInterval.inSeconds == 60 ? 15 : 60;
+    debugPrint('Update forward/rewind interval to $newInterval seconds');
+    AudioService.updateConfig(
+      AudioServiceConfig(
+        rewindInterval: Duration(seconds: newInterval),
+        fastForwardInterval: Duration(seconds: newInterval),
+        notificationColor: Colors.blue,
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -123,6 +137,8 @@ class MainScreen extends StatelessWidget {
                     "Processing state: ${describeEnum(processingState)}");
               },
             ),
+            // Button to update config dynamically (changes forward/rewind interval).
+            _button(Icons.settings, _updateConfig),
           ],
         ),
       ),

--- a/audio_service/example/lib/main.dart
+++ b/audio_service/example/lib/main.dart
@@ -36,6 +36,7 @@ Future<void> main() async {
     config: const AudioServiceConfig(
       androidNotificationChannelId: 'com.ryanheise.myapp.channel.audio',
       androidNotificationChannelName: 'Audio playback',
+      androidNotificationOngoing: true,
       rewindInterval: Duration(seconds: 15),
       fastForwardInterval: Duration(seconds: 15),
     ),
@@ -67,6 +68,7 @@ class MainScreen extends StatelessWidget {
       AudioServiceConfig(
         rewindInterval: Duration(seconds: newInterval),
         fastForwardInterval: Duration(seconds: newInterval),
+        // Example of dynamic notification changes on Android
         notificationColor: Colors.blue,
       ),
     );

--- a/audio_service/lib/audio_service.dart
+++ b/audio_service/lib/audio_service.dart
@@ -1077,8 +1077,8 @@ class AudioService {
     );
   }
 
-  /// Update the AudioService configuration dynamically.
-  /// Only some properties will take effect after init, forward/rewind interval works.
+  /// Update the AudioService configuration. Must be called after init.
+  /// Primarily intended to update how notification behaves during playback.
   static Future<void> updateConfig(AudioServiceConfig config) async {
     _config = config;
     await _platform.configure(ConfigureRequest(config: config._toMessage()));

--- a/audio_service/lib/audio_service.dart
+++ b/audio_service/lib/audio_service.dart
@@ -1077,6 +1077,13 @@ class AudioService {
     );
   }
 
+  /// Update the AudioService configuration dynamically.
+  /// Only some properties will take effect after init, forward/rewind interval works.
+  static Future<void> updateConfig(AudioServiceConfig config) async {
+    _config = config;
+    await _platform.configure(ConfigureRequest(config: config._toMessage()));
+  }
+
   /// Stops the service.
   static Future<void> _stop() async {
     await _platform.stopService(const StopServiceRequest());

--- a/audio_service/pubspec.yaml
+++ b/audio_service/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_service
 description: Flutter plugin to play audio in the background while the screen is off.
-version: 0.18.2
+version: 0.18.3
 homepage: https://github.com/ryanheise/audio_service/tree/master/audio_service
 
 environment:


### PR DESCRIPTION
Allows AudioService to be re-configured after init. This makes it possible to dynamically change iOS forward/rewind interval shown in the control center or fx. the android notification color.

This was a use-case for our app, where the user can quickly change a preferred duration for the forward/rewind skip interval during playback and we'd like the iOS control center to update dynamically without having to stop and re-init the entire AudioService.

And thanks for your work on this feature-rich and very well designed plugin 👍 

## Pre-launch Checklist

- [x] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [x] My change is not breaking and lands in `minor` branch.
- [x] ? How do I check this ? If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I ran `dart analyze`.
- [x] I ran `dart format`.
- [x] I ran `flutter test` and all tests are passing.

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
