### PR TITLE
change PendingIntent to FLAG_IMMUTABLE

### DIFF
--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -336,7 +336,7 @@ public class AudioService extends MediaBrowserServiceCompat {
             intent.setComponent(new ComponentName(context, config.activityClassName));
             //Intent intent = new Intent(context, config.activityClassName);
             intent.setAction(NOTIFICATION_CLICK_ACTION);
-            contentIntent = PendingIntent.getActivity(context, REQUEST_CONTENT_INTENT, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+            contentIntent = PendingIntent.getActivity(context, REQUEST_CONTENT_INTENT, intent, PendingIntent.FLAG_IMMUTABLE);
         } else {
             contentIntent = null;
         }


### PR DESCRIPTION
change the pending intent from FLAG_UPDATE_CURRENT to FLAG_IMMUTABLE.
FLAG_UPDATE_CURRENT cause a crash/error on Android 12

Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles., null, java.lang.IllegalArgumentException: app.aworld: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.

I've tested on simulator with Android 12

*Replace this paragraph with a description of what this PR is changing or adding, and why.*

*If there's an open issue your PR is fixing, please list it here.*

## Pre-launch Checklist

- [ ] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [ ] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [ ] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I ran `dart analyze`.
- [ ] I ran `dart format`.
- [ ] I ran `flutter test` and all tests are passing.

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
