### PR TITLE
895 icon fix

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.18.4
+* Add androids.core:core back to build.gradle. Will Possibly resolve #895 (@yringler)
+
 ## 0.18.3
 
 * Fix build when targeting Android 12.

--- a/audio_service/android/build.gradle
+++ b/audio_service/android/build.gradle
@@ -43,5 +43,6 @@ android {
 }
 
 dependencies {
+    implementation 'androidx.core:core:1.7.0'
     implementation 'androidx.media:media:1.4.3'
 }

--- a/audio_service/pubspec.yaml
+++ b/audio_service/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_service
 description: Flutter plugin to play audio in the background while the screen is off.
-version: 0.18.3
+version: 0.18.4
 homepage: https://github.com/ryanheise/audio_service/tree/master/audio_service
 
 environment:


### PR DESCRIPTION
This PR adds androids.core:core back to build.gradle

*If there's an open issue your PR is fixing, please list it here.*
This may fix #895 - I'm having difficulty replicating.

## Pre-launch Checklist

- [x] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [x] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [x] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I ran `dart analyze`.
- [x] I ran `dart format`.
- [x] I ran `flutter test` and all tests are passing.

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
