### PR TITLE
Added toJson and fromJson to MediaItem

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -27,374 +27,375 @@
 
 ## 0.18.5
 
-* Add AudioServiceFragmentActivity (@deimantasa).
+- Add AudioServiceFragmentActivity (@deimantasa).
 * Support `content://` art URIs in notification on Android (@nt4f04uNd).
 * Document Android foregroundServiceType.
+- Added toJson() and fromJson() methods to MediaItem (@AsjadSiddiqui).
 
 ## 0.18.4
 
-* Fix Android FlutterJNI error after quick relaunch. 
-* Fix Android NPE when destroying additional FlutterEngines.
+- Fix Android FlutterJNI error after quick relaunch.
+- Fix Android NPE when destroying additional FlutterEngines.
 
 ## 0.18.3
 
-* Fix build when targeting Android 12.
+- Fix build when targeting Android 12.
 
 ## 0.18.2
 
-* Guard against NPE when Android service is destroyed quickly.
-* Migrate to flutter_lints.
-* Queue messages from platform if init() called late.
-* Fix deep linking on Android (@vishna/@ryanheise).
+- Guard against NPE when Android service is destroyed quickly.
+- Migrate to flutter_lints.
+- Queue messages from platform if init() called late.
+- Fix deep linking on Android (@vishna/@ryanheise).
 
 ## 0.18.1
 
-* Remove iOS notification on stop.
-* Fix setSpeed action on iOS.
-* Eliminate redundant notification updates on Android.
-* Handle null album and artist on web (@nt4f04uNd).
-* Fix multithreaded crash in notification tap (@nt4f04uNd).
-* Fix regression to show album art on lock screen (@nt4f04uNd).
-* Add playlist/shuffle/loop example.
+- Remove iOS notification on stop.
+- Fix setSpeed action on iOS.
+- Eliminate redundant notification updates on Android.
+- Handle null album and artist on web (@nt4f04uNd).
+- Fix multithreaded crash in notification tap (@nt4f04uNd).
+- Fix regression to show album art on lock screen (@nt4f04uNd).
+- Add playlist/shuffle/loop example.
 
 ## 0.18.0
 
-* Use a single isolate for easier communication.
-* Replace BackgroundAudioTask by AudioHandler.
-* Replace AudioService.start by AudioService.init.
-* Android Auto support.
-* Android 11 media session resumption support.
-* Federated plugin model.
-* Composable audio handlers (@yringler).
-* More callbacks:
-  * prepareFromSearch
-  * prepareFromUri
-  * playFromSearch
-  * playFromUri
-  * addQueueItems
-  * removeQueueItemAt
-  * setCaptioningEnabled
-  * getMediaItem
-  * search
-  * androidSetRemoteVolume
-  * androidAdjustRemoteVolume
-* More state:
-  * queueTitle
-  * ratingStyle
-  * androidPlaybackInfo
-  * customState
-* Default platform implementation for Windows/Linux (@keaganhilliard)
-* iOS/macOS control center bug fixes (@nt4f04uNd)
-* Fix queue index out of bounds bug (@kcrebound)
-* Fix bug when starting foreground service from background (@chengyuhui)
-* Make MediaItem.album nullable (@letiagoalves)
-* Code quality:
-  * Unit tests (@suragch, @nt4f04uNd)
-  * Strong-mode and pedantic lints, code consistency (@nt4f04uNd)
-* Improve artUri performance on Android (@nt4f04uNd)
-* Better detection of browser support (@nt4f04uNd)
+- Use a single isolate for easier communication.
+- Replace BackgroundAudioTask by AudioHandler.
+- Replace AudioService.start by AudioService.init.
+- Android Auto support.
+- Android 11 media session resumption support.
+- Federated plugin model.
+- Composable audio handlers (@yringler).
+- More callbacks:
+  - prepareFromSearch
+  - prepareFromUri
+  - playFromSearch
+  - playFromUri
+  - addQueueItems
+  - removeQueueItemAt
+  - setCaptioningEnabled
+  - getMediaItem
+  - search
+  - androidSetRemoteVolume
+  - androidAdjustRemoteVolume
+- More state:
+  - queueTitle
+  - ratingStyle
+  - androidPlaybackInfo
+  - customState
+- Default platform implementation for Windows/Linux (@keaganhilliard)
+- iOS/macOS control center bug fixes (@nt4f04uNd)
+- Fix queue index out of bounds bug (@kcrebound)
+- Fix bug when starting foreground service from background (@chengyuhui)
+- Make MediaItem.album nullable (@letiagoalves)
+- Code quality:
+  - Unit tests (@suragch, @nt4f04uNd)
+  - Strong-mode and pedantic lints, code consistency (@nt4f04uNd)
+- Improve artUri performance on Android (@nt4f04uNd)
+- Better detection of browser support (@nt4f04uNd)
 
 ## 0.17.1
 
-* Support rxdart 0.27.0.
+- Support rxdart 0.27.0.
 
 ## 0.17.0
 
-* Null safety.
-* Change artUri type from String to Uri.
+- Null safety.
+- Change artUri type from String to Uri.
 
 ## 0.16.2+1
 
-* Mention upcoming 0.18.0 release in README.
+- Mention upcoming 0.18.0 release in README.
 
 ## 0.16.2
 
-* Fix positionStream bug when seek is interrupted by onStop.
-* Fix JS name clash for MediaMetadata.
-* Update NowPlayingInfo speed correctly on iOS (@ryotayama).
+- Fix positionStream bug when seek is interrupted by onStop.
+- Fix JS name clash for MediaMetadata.
+- Update NowPlayingInfo speed correctly on iOS (@ryotayama).
 
 ## 0.16.1
 
-* Fix bug in start() when using HttpOverrides.
+- Fix bug in start() when using HttpOverrides.
 
 ## 0.16.0
 
-* setState parameters default to previous state.
-* Change updateTime from Duration to DateTime.
-* Rename newStartRating to newStarRating.
-* Declare type of MediaItem.extras (@hacker1024).
-* Unit tests.
-* Fix compile error on macOS.
-* Update dependencies.
+- setState parameters default to previous state.
+- Change updateTime from Duration to DateTime.
+- Rename newStartRating to newStarRating.
+- Declare type of MediaItem.extras (@hacker1024).
+- Unit tests.
+- Fix compile error on macOS.
+- Update dependencies.
 
 ## 0.15.3
 
-* Add positionStream and runningStream.
-* Add androidShowNotificationBadge option (@aleexbt).
+- Add positionStream and runningStream.
+- Add androidShowNotificationBadge option (@aleexbt).
 
 ## 0.15.2
 
-* Process connect/disconnect/start requests in a queue.
-* Guard against null setState arguments.
-* Range check in onSkipToPrevious (@snaeji).
+- Process connect/disconnect/start requests in a queue.
+- Guard against null setState arguments.
+- Range check in onSkipToPrevious (@snaeji).
 
 ## 0.15.1
 
-* Fix loading of file:// artUri values.
-* Allow booleans/doubles in MediaItems.
-* Silently ignore duplicate onStop requests.
+- Fix loading of file:// artUri values.
+- Allow booleans/doubles in MediaItems.
+- Silently ignore duplicate onStop requests.
 
 ## 0.15.0
 
-* Web support (@keaganhilliard)
-* macOS support (@hacker1024)
-* Route next/previous buttons to onClick on Android (@stonega)
-* Correctly scale skip intervals for control center (@subhash279)
-* Handle repeated stop/start calls more robustly.
-* Fix Android 11 bugs.
+- Web support (@keaganhilliard)
+- macOS support (@hacker1024)
+- Route next/previous buttons to onClick on Android (@stonega)
+- Correctly scale skip intervals for control center (@subhash279)
+- Handle repeated stop/start calls more robustly.
+- Fix Android 11 bugs.
 
 ## 0.14.1
 
-* audio_session dependency now supports minSdkVersion 16 on Android.
+- audio_session dependency now supports minSdkVersion 16 on Android.
 
 ## 0.14.0
 
-* audio session management now handled by audio_session (see [Migration Guide](https://github.com/ryanheise/audio_service/wiki/Migration-Guide#0140)).
-* Exceptions in background audio task are logged and forwarded to client.
+- audio session management now handled by audio_session (see [Migration Guide](https://github.com/ryanheise/audio_service/wiki/Migration-Guide#0140)).
+- Exceptions in background audio task are logged and forwarded to client.
 
 ## 0.13.0
 
-* All BackgroundAudioTask callbacks are now async.
-* Add default implementation of onSkipToNext/onSkipToPrevious.
-* Bug fixes.
+- All BackgroundAudioTask callbacks are now async.
+- Add default implementation of onSkipToNext/onSkipToPrevious.
+- Bug fixes.
 
 ## 0.12.0
 
-* Add setRepeatMode/setShuffleMode.
-* Enable iOS Control Center buttons based on setState.
-* Support seek forward/backward in iOS Control Center.
-* Add default behaviour to BackgroundAudioTask.
-* Bug fixes.
-* Simplify example.
+- Add setRepeatMode/setShuffleMode.
+- Enable iOS Control Center buttons based on setState.
+- Support seek forward/backward in iOS Control Center.
+- Add default behaviour to BackgroundAudioTask.
+- Bug fixes.
+- Simplify example.
 
 ## 0.11.2
 
-* Fix bug with album metadata on Android.
+- Fix bug with album metadata on Android.
 
 ## 0.11.1
 
-* Allow setting the iOS audio session category and options.
-* Allow AudioServiceWidget to recognise swipe gesture on iOS.
-* Check for null title and album on Android.
+- Allow setting the iOS audio session category and options.
+- Allow AudioServiceWidget to recognise swipe gesture on iOS.
+- Check for null title and album on Android.
 
 ## 0.11.0
 
-* Breaking change: onStop must await super.onStop to shutdown task.
-* Fix Android memory leak.
+- Breaking change: onStop must await super.onStop to shutdown task.
+- Fix Android memory leak.
 
 ## 0.10.0
 
-* Replace androidStopOnRemoveTask with onTaskRemoved callback.
-* Add onClose callback.
-* Breaking change: new MediaButtonReceiver in AndroidManifest.xml.
+- Replace androidStopOnRemoveTask with onTaskRemoved callback.
+- Add onClose callback.
+- Breaking change: new MediaButtonReceiver in AndroidManifest.xml.
 
 ## 0.9.0
 
-* New state model: split into playing + processingState.
-* androidStopForegroundOnPause ties foreground state to playing state.
-* Add MediaItem.toJson/fromJson.
-* Add AudioService.notificationClickEventStream (Android).
-* Add AudioService.updateMediaItem.
-* Add AudioService.setSpeed.
-* Add PlaybackState.bufferedPosition.
-* Add custom AudioService.start parameters.
-* Rename replaceQueue -> updateQueue.
-* Rename Android-specific start parameters with android- prefix.
-* Use Duration type for all time values.
-* Pass fastForward/rewind intervals through to background task.
-* Allow connections from background contexts (e.g. android_alarm_manager).
-* Unify iOS/Android focus APIs.
-* Bug fixes and dependency updates.
+- New state model: split into playing + processingState.
+- androidStopForegroundOnPause ties foreground state to playing state.
+- Add MediaItem.toJson/fromJson.
+- Add AudioService.notificationClickEventStream (Android).
+- Add AudioService.updateMediaItem.
+- Add AudioService.setSpeed.
+- Add PlaybackState.bufferedPosition.
+- Add custom AudioService.start parameters.
+- Rename replaceQueue -> updateQueue.
+- Rename Android-specific start parameters with android- prefix.
+- Use Duration type for all time values.
+- Pass fastForward/rewind intervals through to background task.
+- Allow connections from background contexts (e.g. android_alarm_manager).
+- Unify iOS/Android focus APIs.
+- Bug fixes and dependency updates.
 
 ## 0.8.0
 
-* Allow UI to await the result of custom actions.
-* Allow background to broadcast custom events to UI.
-* Improve memory management for art bitmaps on Android.
-* Convenience methods: replaceQueue, playMediaItem, addQueueItems.
-* Bug fixes and dependency updates.
+- Allow UI to await the result of custom actions.
+- Allow background to broadcast custom events to UI.
+- Improve memory management for art bitmaps on Android.
+- Convenience methods: replaceQueue, playMediaItem, addQueueItems.
+- Bug fixes and dependency updates.
 
 ## 0.7.2
 
-* Shutdown background task if task killed by IO (Android).
-* Bug fixes and dependency updates.
+- Shutdown background task if task killed by IO (Android).
+- Bug fixes and dependency updates.
 
 ## 0.7.1
 
-* Add AudioServiceWidget to auto-manage connections.
-* Allow file URIs for artUri.
+- Add AudioServiceWidget to auto-manage connections.
+- Allow file URIs for artUri.
 
 ## 0.7.0
 
-* Support skip forward/backward in command center (iOS).
-* Add 'extras' field to MediaItem.
-* Artwork caching and preloading supported on Android+iOS.
-* Bug fixes.
+- Support skip forward/backward in command center (iOS).
+- Add 'extras' field to MediaItem.
+- Artwork caching and preloading supported on Android+iOS.
+- Bug fixes.
 
 ## 0.6.2
 
-* Bug fixes.
+- Bug fixes.
 
 ## 0.6.1
 
-* Option to stop service on closing task (Android).
+- Option to stop service on closing task (Android).
 
 ## 0.6.0
 
-* Migrated to V2 embedding API (Flutter 1.12).
+- Migrated to V2 embedding API (Flutter 1.12).
 
 ## 0.5.7
 
-* Destroy isolates after use.
+- Destroy isolates after use.
 
 ## 0.5.6
 
-* Support Flutter 1.12.
+- Support Flutter 1.12.
 
 ## 0.5.5
 
-* Bump sdk version to 2.6.0.
+- Bump sdk version to 2.6.0.
 
 ## 0.5.4
 
-* Fix Android memory leak.
+- Fix Android memory leak.
 
 ## 0.5.3
 
-* Support Queue, album art and other missing features on iOS.
+- Support Queue, album art and other missing features on iOS.
 
 ## 0.5.2
 
-* Update documentation and example.
+- Update documentation and example.
 
 ## 0.5.1
 
-* Playback state broadcast on connect (iOS).
+- Playback state broadcast on connect (iOS).
 
 ## 0.5.0
 
-* Partial iOS support.
+- Partial iOS support.
 
 ## 0.4.2
 
-* Option to call stopForeground on pause.
+- Option to call stopForeground on pause.
 
 ## 0.4.1
 
-* Fix queue support bug
+- Fix queue support bug
 
 ## 0.4.0
 
-* Breaking change: AudioServiceBackground.run takes a single parameter.
+- Breaking change: AudioServiceBackground.run takes a single parameter.
 
 ## 0.3.1
 
-* Update example to disconnect when pressing back button.
+- Update example to disconnect when pressing back button.
 
 ## 0.3.0
 
-* Breaking change: updateTime now measured since epoch instead of boot time.
+- Breaking change: updateTime now measured since epoch instead of boot time.
 
 ## 0.2.1
 
-* Streams use RxDart BehaviorSubject.
+- Streams use RxDart BehaviorSubject.
 
 ## 0.2.0
 
-* Migrate to AndroidX.
+- Migrate to AndroidX.
 
 ## 0.1.1
 
-* Bump targetSdkVersion to 28
-* Clear client-side metadata and state on stop.
+- Bump targetSdkVersion to 28
+- Clear client-side metadata and state on stop.
 
 ## 0.1.0
 
-* onClick is now always called for media button clicks.
-* Option to set notifications as ongoing.
+- onClick is now always called for media button clicks.
+- Option to set notifications as ongoing.
 
 ## 0.0.15
 
-* Option to set subText in notification.
-* Support media item ratings
+- Option to set subText in notification.
+- Support media item ratings
 
 ## 0.0.14
 
-* Can update existing media items.
-* Can specify order of Android notification compact actions.
-* Bug fix with connect.
+- Can update existing media items.
+- Can specify order of Android notification compact actions.
+- Bug fix with connect.
 
 ## 0.0.13
 
-* Option to preload artwork.
-* Allow client to browse media items.
+- Option to preload artwork.
+- Allow client to browse media items.
 
 ## 0.0.12
 
-* More options to customise the notification content.
+- More options to customise the notification content.
 
 ## 0.0.11
 
-* Breaking API changes.
-* Connection callbacks replaced by a streams API.
-* AudioService properties for playbackState, currentMediaItem, queue.
-* Option to set Android notification channel description.
-* AudioService.customAction awaits completion of the action.
+- Breaking API changes.
+- Connection callbacks replaced by a streams API.
+- AudioService properties for playbackState, currentMediaItem, queue.
+- Option to set Android notification channel description.
+- AudioService.customAction awaits completion of the action.
 
 ## 0.0.10
 
-* Bug fixes with queue management.
-* AudioService.start completes when the background task is ready.
+- Bug fixes with queue management.
+- AudioService.start completes when the background task is ready.
 
 ## 0.0.9
 
-* Support queue management.
+- Support queue management.
 
 ## 0.0.8
 
-* Bug fix.
+- Bug fix.
 
 ## 0.0.7
 
-* onMediaChanged takes MediaItem parameter.
-* Support playFromMediaId, fastForward, rewind.
+- onMediaChanged takes MediaItem parameter.
+- Support playFromMediaId, fastForward, rewind.
 
 ## 0.0.6
 
-* All APIs address media items by String mediaId.
+- All APIs address media items by String mediaId.
 
 ## 0.0.5
 
-* Show media art in notification and lock screen.
+- Show media art in notification and lock screen.
 
 ## 0.0.4
 
-* Support and example for playing TextToSpeech.
-* Click notification to launch UI.
-* More properties added to MediaItem.
-* Minor API changes.
+- Support and example for playing TextToSpeech.
+- Click notification to launch UI.
+- More properties added to MediaItem.
+- Minor API changes.
 
 ## 0.0.3
 
-* Pause now keeps background isolate running
-* Notification channel id is generated from package name
-* Updated example to use audioplayer plugin
-* Fixed media button handling
+- Pause now keeps background isolate running
+- Notification channel id is generated from package name
+- Updated example to use audioplayer plugin
+- Fixed media button handling
 
 ## 0.0.2
 
-* Better connection handling.
+- Better connection handling.
 
 ## 0.0.1
 
-* Initial release.
+- Initial release.

--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -27,375 +27,375 @@
 
 ## 0.18.5
 
-- Add AudioServiceFragmentActivity (@deimantasa).
+* Add AudioServiceFragmentActivity (@deimantasa).
 * Support `content://` art URIs in notification on Android (@nt4f04uNd).
 * Document Android foregroundServiceType.
-- Added toJson() and fromJson() methods to MediaItem (@AsjadSiddiqui).
+* Added toJson() and fromJson() methods to MediaItem (@AsjadSiddiqui).
 
 ## 0.18.4
 
-- Fix Android FlutterJNI error after quick relaunch.
-- Fix Android NPE when destroying additional FlutterEngines.
+* Fix Android FlutterJNI error after quick relaunch. 
+* Fix Android NPE when destroying additional FlutterEngines.
 
 ## 0.18.3
 
-- Fix build when targeting Android 12.
+* Fix build when targeting Android 12.
 
 ## 0.18.2
 
-- Guard against NPE when Android service is destroyed quickly.
-- Migrate to flutter_lints.
-- Queue messages from platform if init() called late.
-- Fix deep linking on Android (@vishna/@ryanheise).
+* Guard against NPE when Android service is destroyed quickly.
+* Migrate to flutter_lints.
+* Queue messages from platform if init() called late.
+* Fix deep linking on Android (@vishna/@ryanheise).
 
 ## 0.18.1
 
-- Remove iOS notification on stop.
-- Fix setSpeed action on iOS.
-- Eliminate redundant notification updates on Android.
-- Handle null album and artist on web (@nt4f04uNd).
-- Fix multithreaded crash in notification tap (@nt4f04uNd).
-- Fix regression to show album art on lock screen (@nt4f04uNd).
-- Add playlist/shuffle/loop example.
+* Remove iOS notification on stop.
+* Fix setSpeed action on iOS.
+* Eliminate redundant notification updates on Android.
+* Handle null album and artist on web (@nt4f04uNd).
+* Fix multithreaded crash in notification tap (@nt4f04uNd).
+* Fix regression to show album art on lock screen (@nt4f04uNd).
+* Add playlist/shuffle/loop example.
 
 ## 0.18.0
 
-- Use a single isolate for easier communication.
-- Replace BackgroundAudioTask by AudioHandler.
-- Replace AudioService.start by AudioService.init.
-- Android Auto support.
-- Android 11 media session resumption support.
-- Federated plugin model.
-- Composable audio handlers (@yringler).
-- More callbacks:
-  - prepareFromSearch
-  - prepareFromUri
-  - playFromSearch
-  - playFromUri
-  - addQueueItems
-  - removeQueueItemAt
-  - setCaptioningEnabled
-  - getMediaItem
-  - search
-  - androidSetRemoteVolume
-  - androidAdjustRemoteVolume
-- More state:
-  - queueTitle
-  - ratingStyle
-  - androidPlaybackInfo
-  - customState
-- Default platform implementation for Windows/Linux (@keaganhilliard)
-- iOS/macOS control center bug fixes (@nt4f04uNd)
-- Fix queue index out of bounds bug (@kcrebound)
-- Fix bug when starting foreground service from background (@chengyuhui)
-- Make MediaItem.album nullable (@letiagoalves)
-- Code quality:
-  - Unit tests (@suragch, @nt4f04uNd)
-  - Strong-mode and pedantic lints, code consistency (@nt4f04uNd)
-- Improve artUri performance on Android (@nt4f04uNd)
-- Better detection of browser support (@nt4f04uNd)
+* Use a single isolate for easier communication.
+* Replace BackgroundAudioTask by AudioHandler.
+* Replace AudioService.start by AudioService.init.
+* Android Auto support.
+* Android 11 media session resumption support.
+* Federated plugin model.
+* Composable audio handlers (@yringler).
+* More callbacks:
+  * prepareFromSearch
+  * prepareFromUri
+  * playFromSearch
+  * playFromUri
+  * addQueueItems
+  * removeQueueItemAt
+  * setCaptioningEnabled
+  * getMediaItem
+  * search
+  * androidSetRemoteVolume
+  * androidAdjustRemoteVolume
+* More state:
+  * queueTitle
+  * ratingStyle
+  * androidPlaybackInfo
+  * customState
+* Default platform implementation for Windows/Linux (@keaganhilliard)
+* iOS/macOS control center bug fixes (@nt4f04uNd)
+* Fix queue index out of bounds bug (@kcrebound)
+* Fix bug when starting foreground service from background (@chengyuhui)
+* Make MediaItem.album nullable (@letiagoalves)
+* Code quality:
+  * Unit tests (@suragch, @nt4f04uNd)
+  * Strong-mode and pedantic lints, code consistency (@nt4f04uNd)
+* Improve artUri performance on Android (@nt4f04uNd)
+* Better detection of browser support (@nt4f04uNd)
 
 ## 0.17.1
 
-- Support rxdart 0.27.0.
+* Support rxdart 0.27.0.
 
 ## 0.17.0
 
-- Null safety.
-- Change artUri type from String to Uri.
+* Null safety.
+* Change artUri type from String to Uri.
 
 ## 0.16.2+1
 
-- Mention upcoming 0.18.0 release in README.
+* Mention upcoming 0.18.0 release in README.
 
 ## 0.16.2
 
-- Fix positionStream bug when seek is interrupted by onStop.
-- Fix JS name clash for MediaMetadata.
-- Update NowPlayingInfo speed correctly on iOS (@ryotayama).
+* Fix positionStream bug when seek is interrupted by onStop.
+* Fix JS name clash for MediaMetadata.
+* Update NowPlayingInfo speed correctly on iOS (@ryotayama).
 
 ## 0.16.1
 
-- Fix bug in start() when using HttpOverrides.
+* Fix bug in start() when using HttpOverrides.
 
 ## 0.16.0
 
-- setState parameters default to previous state.
-- Change updateTime from Duration to DateTime.
-- Rename newStartRating to newStarRating.
-- Declare type of MediaItem.extras (@hacker1024).
-- Unit tests.
-- Fix compile error on macOS.
-- Update dependencies.
+* setState parameters default to previous state.
+* Change updateTime from Duration to DateTime.
+* Rename newStartRating to newStarRating.
+* Declare type of MediaItem.extras (@hacker1024).
+* Unit tests.
+* Fix compile error on macOS.
+* Update dependencies.
 
 ## 0.15.3
 
-- Add positionStream and runningStream.
-- Add androidShowNotificationBadge option (@aleexbt).
+* Add positionStream and runningStream.
+* Add androidShowNotificationBadge option (@aleexbt).
 
 ## 0.15.2
 
-- Process connect/disconnect/start requests in a queue.
-- Guard against null setState arguments.
-- Range check in onSkipToPrevious (@snaeji).
+* Process connect/disconnect/start requests in a queue.
+* Guard against null setState arguments.
+* Range check in onSkipToPrevious (@snaeji).
 
 ## 0.15.1
 
-- Fix loading of file:// artUri values.
-- Allow booleans/doubles in MediaItems.
-- Silently ignore duplicate onStop requests.
+* Fix loading of file:// artUri values.
+* Allow booleans/doubles in MediaItems.
+* Silently ignore duplicate onStop requests.
 
 ## 0.15.0
 
-- Web support (@keaganhilliard)
-- macOS support (@hacker1024)
-- Route next/previous buttons to onClick on Android (@stonega)
-- Correctly scale skip intervals for control center (@subhash279)
-- Handle repeated stop/start calls more robustly.
-- Fix Android 11 bugs.
+* Web support (@keaganhilliard)
+* macOS support (@hacker1024)
+* Route next/previous buttons to onClick on Android (@stonega)
+* Correctly scale skip intervals for control center (@subhash279)
+* Handle repeated stop/start calls more robustly.
+* Fix Android 11 bugs.
 
 ## 0.14.1
 
-- audio_session dependency now supports minSdkVersion 16 on Android.
+* audio_session dependency now supports minSdkVersion 16 on Android.
 
 ## 0.14.0
 
-- audio session management now handled by audio_session (see [Migration Guide](https://github.com/ryanheise/audio_service/wiki/Migration-Guide#0140)).
-- Exceptions in background audio task are logged and forwarded to client.
+* audio session management now handled by audio_session (see [Migration Guide](https://github.com/ryanheise/audio_service/wiki/Migration-Guide#0140)).
+* Exceptions in background audio task are logged and forwarded to client.
 
 ## 0.13.0
 
-- All BackgroundAudioTask callbacks are now async.
-- Add default implementation of onSkipToNext/onSkipToPrevious.
-- Bug fixes.
+* All BackgroundAudioTask callbacks are now async.
+* Add default implementation of onSkipToNext/onSkipToPrevious.
+* Bug fixes.
 
 ## 0.12.0
 
-- Add setRepeatMode/setShuffleMode.
-- Enable iOS Control Center buttons based on setState.
-- Support seek forward/backward in iOS Control Center.
-- Add default behaviour to BackgroundAudioTask.
-- Bug fixes.
-- Simplify example.
+* Add setRepeatMode/setShuffleMode.
+* Enable iOS Control Center buttons based on setState.
+* Support seek forward/backward in iOS Control Center.
+* Add default behaviour to BackgroundAudioTask.
+* Bug fixes.
+* Simplify example.
 
 ## 0.11.2
 
-- Fix bug with album metadata on Android.
+* Fix bug with album metadata on Android.
 
 ## 0.11.1
 
-- Allow setting the iOS audio session category and options.
-- Allow AudioServiceWidget to recognise swipe gesture on iOS.
-- Check for null title and album on Android.
+* Allow setting the iOS audio session category and options.
+* Allow AudioServiceWidget to recognise swipe gesture on iOS.
+* Check for null title and album on Android.
 
 ## 0.11.0
 
-- Breaking change: onStop must await super.onStop to shutdown task.
-- Fix Android memory leak.
+* Breaking change: onStop must await super.onStop to shutdown task.
+* Fix Android memory leak.
 
 ## 0.10.0
 
-- Replace androidStopOnRemoveTask with onTaskRemoved callback.
-- Add onClose callback.
-- Breaking change: new MediaButtonReceiver in AndroidManifest.xml.
+* Replace androidStopOnRemoveTask with onTaskRemoved callback.
+* Add onClose callback.
+* Breaking change: new MediaButtonReceiver in AndroidManifest.xml.
 
 ## 0.9.0
 
-- New state model: split into playing + processingState.
-- androidStopForegroundOnPause ties foreground state to playing state.
-- Add MediaItem.toJson/fromJson.
-- Add AudioService.notificationClickEventStream (Android).
-- Add AudioService.updateMediaItem.
-- Add AudioService.setSpeed.
-- Add PlaybackState.bufferedPosition.
-- Add custom AudioService.start parameters.
-- Rename replaceQueue -> updateQueue.
-- Rename Android-specific start parameters with android- prefix.
-- Use Duration type for all time values.
-- Pass fastForward/rewind intervals through to background task.
-- Allow connections from background contexts (e.g. android_alarm_manager).
-- Unify iOS/Android focus APIs.
-- Bug fixes and dependency updates.
+* New state model: split into playing + processingState.
+* androidStopForegroundOnPause ties foreground state to playing state.
+* Add MediaItem.toJson/fromJson.
+* Add AudioService.notificationClickEventStream (Android).
+* Add AudioService.updateMediaItem.
+* Add AudioService.setSpeed.
+* Add PlaybackState.bufferedPosition.
+* Add custom AudioService.start parameters.
+* Rename replaceQueue -> updateQueue.
+* Rename Android-specific start parameters with android- prefix.
+* Use Duration type for all time values.
+* Pass fastForward/rewind intervals through to background task.
+* Allow connections from background contexts (e.g. android_alarm_manager).
+* Unify iOS/Android focus APIs.
+* Bug fixes and dependency updates.
 
 ## 0.8.0
 
-- Allow UI to await the result of custom actions.
-- Allow background to broadcast custom events to UI.
-- Improve memory management for art bitmaps on Android.
-- Convenience methods: replaceQueue, playMediaItem, addQueueItems.
-- Bug fixes and dependency updates.
+* Allow UI to await the result of custom actions.
+* Allow background to broadcast custom events to UI.
+* Improve memory management for art bitmaps on Android.
+* Convenience methods: replaceQueue, playMediaItem, addQueueItems.
+* Bug fixes and dependency updates.
 
 ## 0.7.2
 
-- Shutdown background task if task killed by IO (Android).
-- Bug fixes and dependency updates.
+* Shutdown background task if task killed by IO (Android).
+* Bug fixes and dependency updates.
 
 ## 0.7.1
 
-- Add AudioServiceWidget to auto-manage connections.
-- Allow file URIs for artUri.
+* Add AudioServiceWidget to auto-manage connections.
+* Allow file URIs for artUri.
 
 ## 0.7.0
 
-- Support skip forward/backward in command center (iOS).
-- Add 'extras' field to MediaItem.
-- Artwork caching and preloading supported on Android+iOS.
-- Bug fixes.
+* Support skip forward/backward in command center (iOS).
+* Add 'extras' field to MediaItem.
+* Artwork caching and preloading supported on Android+iOS.
+* Bug fixes.
 
 ## 0.6.2
 
-- Bug fixes.
+* Bug fixes.
 
 ## 0.6.1
 
-- Option to stop service on closing task (Android).
+* Option to stop service on closing task (Android).
 
 ## 0.6.0
 
-- Migrated to V2 embedding API (Flutter 1.12).
+* Migrated to V2 embedding API (Flutter 1.12).
 
 ## 0.5.7
 
-- Destroy isolates after use.
+* Destroy isolates after use.
 
 ## 0.5.6
 
-- Support Flutter 1.12.
+* Support Flutter 1.12.
 
 ## 0.5.5
 
-- Bump sdk version to 2.6.0.
+* Bump sdk version to 2.6.0.
 
 ## 0.5.4
 
-- Fix Android memory leak.
+* Fix Android memory leak.
 
 ## 0.5.3
 
-- Support Queue, album art and other missing features on iOS.
+* Support Queue, album art and other missing features on iOS.
 
 ## 0.5.2
 
-- Update documentation and example.
+* Update documentation and example.
 
 ## 0.5.1
 
-- Playback state broadcast on connect (iOS).
+* Playback state broadcast on connect (iOS).
 
 ## 0.5.0
 
-- Partial iOS support.
+* Partial iOS support.
 
 ## 0.4.2
 
-- Option to call stopForeground on pause.
+* Option to call stopForeground on pause.
 
 ## 0.4.1
 
-- Fix queue support bug
+* Fix queue support bug
 
 ## 0.4.0
 
-- Breaking change: AudioServiceBackground.run takes a single parameter.
+* Breaking change: AudioServiceBackground.run takes a single parameter.
 
 ## 0.3.1
 
-- Update example to disconnect when pressing back button.
+* Update example to disconnect when pressing back button.
 
 ## 0.3.0
 
-- Breaking change: updateTime now measured since epoch instead of boot time.
+* Breaking change: updateTime now measured since epoch instead of boot time.
 
 ## 0.2.1
 
-- Streams use RxDart BehaviorSubject.
+* Streams use RxDart BehaviorSubject.
 
 ## 0.2.0
 
-- Migrate to AndroidX.
+* Migrate to AndroidX.
 
 ## 0.1.1
 
-- Bump targetSdkVersion to 28
-- Clear client-side metadata and state on stop.
+* Bump targetSdkVersion to 28
+* Clear client-side metadata and state on stop.
 
 ## 0.1.0
 
-- onClick is now always called for media button clicks.
-- Option to set notifications as ongoing.
+* onClick is now always called for media button clicks.
+* Option to set notifications as ongoing.
 
 ## 0.0.15
 
-- Option to set subText in notification.
-- Support media item ratings
+* Option to set subText in notification.
+* Support media item ratings
 
 ## 0.0.14
 
-- Can update existing media items.
-- Can specify order of Android notification compact actions.
-- Bug fix with connect.
+* Can update existing media items.
+* Can specify order of Android notification compact actions.
+* Bug fix with connect.
 
 ## 0.0.13
 
-- Option to preload artwork.
-- Allow client to browse media items.
+* Option to preload artwork.
+* Allow client to browse media items.
 
 ## 0.0.12
 
-- More options to customise the notification content.
+* More options to customise the notification content.
 
 ## 0.0.11
 
-- Breaking API changes.
-- Connection callbacks replaced by a streams API.
-- AudioService properties for playbackState, currentMediaItem, queue.
-- Option to set Android notification channel description.
-- AudioService.customAction awaits completion of the action.
+* Breaking API changes.
+* Connection callbacks replaced by a streams API.
+* AudioService properties for playbackState, currentMediaItem, queue.
+* Option to set Android notification channel description.
+* AudioService.customAction awaits completion of the action.
 
 ## 0.0.10
 
-- Bug fixes with queue management.
-- AudioService.start completes when the background task is ready.
+* Bug fixes with queue management.
+* AudioService.start completes when the background task is ready.
 
 ## 0.0.9
 
-- Support queue management.
+* Support queue management.
 
 ## 0.0.8
 
-- Bug fix.
+* Bug fix.
 
 ## 0.0.7
 
-- onMediaChanged takes MediaItem parameter.
-- Support playFromMediaId, fastForward, rewind.
+* onMediaChanged takes MediaItem parameter.
+* Support playFromMediaId, fastForward, rewind.
 
 ## 0.0.6
 
-- All APIs address media items by String mediaId.
+* All APIs address media items by String mediaId.
 
 ## 0.0.5
 
-- Show media art in notification and lock screen.
+* Show media art in notification and lock screen.
 
 ## 0.0.4
 
-- Support and example for playing TextToSpeech.
-- Click notification to launch UI.
-- More properties added to MediaItem.
-- Minor API changes.
+* Support and example for playing TextToSpeech.
+* Click notification to launch UI.
+* More properties added to MediaItem.
+* Minor API changes.
 
 ## 0.0.3
 
-- Pause now keeps background isolate running
-- Notification channel id is generated from package name
-- Updated example to use audioplayer plugin
-- Fixed media button handling
+* Pause now keeps background isolate running
+* Notification channel id is generated from package name
+* Updated example to use audioplayer plugin
+* Fixed media button handling
 
 ## 0.0.2
 
-- Better connection handling.
+* Better connection handling.
 
 ## 0.0.1
 
-- Initial release.
+* Initial release.

--- a/audio_service/lib/audio_service.dart
+++ b/audio_service/lib/audio_service.dart
@@ -674,6 +674,31 @@ class MediaItem {
         extras: extras,
       );
 
+  // Converts this [MediaItem] to a map of key/value pairs corresponding to
+  /// the fields of this class.
+  Map<String, dynamic> toJson() => _toMessage().toMap();
+
+  /// Creates a [MediaItem] from a map of key/value pairs corresponding to
+  /// fields of this class.
+  factory MediaItem.fromJson(Map raw) => MediaItem(
+        id: raw['id'] as String,
+        title: raw['title'] as String,
+        album: raw['album'] as String?,
+        artist: raw['artist'] as String?,
+        genre: raw['genre'] as String?,
+        duration: raw['duration'] != null
+            ? Duration(milliseconds: raw['duration'] as int)
+            : null,
+        artUri:
+            raw['artUri'] != null ? Uri.parse(raw['artUri'] as String) : null,
+        playable: raw['playable'] as bool?,
+        displayTitle: raw['displayTitle'] as String?,
+        displaySubtitle: raw['displaySubtitle'] as String?,
+        displayDescription: raw['displayDescription'] as String?,
+        rating: null,
+        extras: (raw['extras'] as Map?)!.cast<String, dynamic>(),
+      );
+
   @override
   String toString() => '${_toMessage().toMap()}';
 }


### PR DESCRIPTION
I recently upgraded my App from Audio Service version 0.17.1 to 0.18.4
Our app was saving the user queue which is a list of `MediaItem` using Hive database. The `json.encode` method uses the `toJson` and `fromJson` methods.
After upgrading we were getting exceptions and were unable to use the `json.encode` method to save the user queue because the `toJson` and `fromJson` methods had been removed.
I would like to know the reason for removing them, and if possible, bring them back.

## Pre-launch Checklist

- [x] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [x] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [x] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I ran `dart analyze`.
- [x] I ran `dart format`.
- [x] I ran `flutter test` and all tests are passing.
