### PR TITLE
Added Android Auto manifest entry for example app

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.18.5
 
 * Add AudioServiceFragmentActivity.
+* Added android auto manifest entry for example app
 
 ## 0.18.4
 

--- a/audio_service/example/android/app/src/main/AndroidManifest.xml
+++ b/audio_service/example/android/app/src/main/AndroidManifest.xml
@@ -40,5 +40,8 @@
             android:name="flutterEmbedding"
             android:value="2" />
 
+        <meta-data android:name="com.google.android.gms.car.application"
+            android:resource="@xml/automotive_app_desc"/>
+
     </application>
 </manifest>

--- a/audio_service/example/android/app/src/main/res/xml/automotive_app_desc.xml
+++ b/audio_service/example/android/app/src/main/res/xml/automotive_app_desc.xml
@@ -1,0 +1,3 @@
+<automotiveApp>
+    <uses name="media"/>
+</automotiveApp>


### PR DESCRIPTION
Android Auto does not recognize the example app. For this reason I've added the necessary Android Auto meta-data entry to the manifest of the example app as described here: https://developer.android.com/training/cars/media/auto