### PR TITLE
Propagate extras to media item

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.18.6
+
+* Migrate to androidx.media 1.6.0 (@snipd-mikel)
+* Propagate MediaItem extras to Android Auto (@snipd-mikel)
+* Update progress bar in Android Auto (@snipd-mikel)
+
 ## 0.18.5
 
 * Add AudioServiceFragmentActivity (@deimantasa).

--- a/audio_service/android/build.gradle
+++ b/audio_service/android/build.gradle
@@ -43,5 +43,5 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.media:media:1.4.3'
+    implementation 'androidx.media:media:1.6.0'
 }

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -34,6 +34,7 @@ import androidx.core.app.NotificationCompat;
 import androidx.media.MediaBrowserServiceCompat;
 import androidx.media.VolumeProviderCompat;
 import androidx.media.app.NotificationCompat.MediaStyle;
+import androidx.media.utils.MediaConstants;
 
 import java.io.FileDescriptor;
 import java.io.FileNotFoundException;
@@ -474,6 +475,15 @@ public class AudioService extends MediaBrowserServiceCompat {
             stateBuilder.setErrorMessage(errorCode, errorMessage);
         else if (errorMessage != null)
             stateBuilder.setErrorMessage(-987654, errorMessage);
+
+        if (mediaMetadata != null) {
+            // Update the progress bar in the browse view as content is playing as explained
+            // here: https://developer.android.com/training/cars/media#browse-progress-bar
+            Bundle extras = new Bundle();
+            extras.putString(MediaConstants.PLAYBACK_STATE_EXTRAS_KEY_MEDIA_ID, mediaMetadata.getDescription().getMediaId());
+            stateBuilder.setExtras(extras);
+        }
+
         mediaSession.setPlaybackState(stateBuilder.build());
         mediaSession.setRepeatMode(repeatMode);
         mediaSession.setShuffleMode(shuffleMode);

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
@@ -543,8 +543,7 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
                         @SuppressWarnings("unchecked") List<Map<?, ?>> rawMediaItems = (List<Map<?, ?>>)response.get("children");
                         List<MediaBrowserCompat.MediaItem> mediaItems = new ArrayList<>();
                         for (Map<?, ?> rawMediaItem : rawMediaItems) {
-                            MediaMetadataCompat mediaMetadata = createMediaMetadata(rawMediaItem);
-                            mediaItems.add(new MediaBrowserCompat.MediaItem(mediaMetadata.getDescription(), (Boolean)rawMediaItem.get("playable") ? MediaBrowserCompat.MediaItem.FLAG_PLAYABLE : MediaBrowserCompat.MediaItem.FLAG_BROWSABLE));
+                            mediaItems.add(rawToMediaItem(rawMediaItem));
                         }
                         result.sendResult(mediaItems);
                     }
@@ -575,8 +574,7 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
                         Map<?, ?> response = (Map<?, ?>)obj;
                         Map<?, ?> rawMediaItem = (Map<?, ?>)response.get("mediaItem");
                         if (rawMediaItem != null) {
-                            MediaMetadataCompat mediaMetadata = createMediaMetadata(rawMediaItem);
-                            MediaBrowserCompat.MediaItem mediaItem = new MediaBrowserCompat.MediaItem(mediaMetadata.getDescription(), (Boolean)rawMediaItem.get("playable") ? MediaBrowserCompat.MediaItem.FLAG_PLAYABLE : MediaBrowserCompat.MediaItem.FLAG_BROWSABLE);
+                            MediaBrowserCompat.MediaItem mediaItem = rawToMediaItem(rawMediaItem);
                             result.sendResult(mediaItem);
                         } else {
                             result.sendResult(null);
@@ -610,8 +608,7 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
                         @SuppressWarnings("unchecked") List<Map<?, ?>> rawMediaItems = (List<Map<?, ?>>)response.get("mediaItems");
                         List<MediaBrowserCompat.MediaItem> mediaItems = new ArrayList<>();
                         for (Map<?, ?> rawMediaItem : rawMediaItems) {
-                            MediaMetadataCompat mediaMetadata = createMediaMetadata(rawMediaItem);
-                            mediaItems.add(new MediaBrowserCompat.MediaItem(mediaMetadata.getDescription(), (Boolean)rawMediaItem.get("playable") ? MediaBrowserCompat.MediaItem.FLAG_PLAYABLE : MediaBrowserCompat.MediaItem.FLAG_BROWSABLE));
+                            mediaItems.add(rawToMediaItem(rawMediaItem));
                         }
                         result.sendResult(mediaItems);
                     }
@@ -1115,12 +1112,48 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
         );
     }
 
+    /**
+     * Propagate mediaItem extras passed from dart to the description. By default, when creating
+     * a MediaMetadataCompat object, it doesn't propagate all the extras to the MediaDescription
+     * instance it holds.
+     *
+     * @param description original description object
+     * @param extras extras map coming from dart
+     * @return description with added extras
+     */
+    private static MediaDescriptionCompat addExtrasToMediaDescription(MediaDescriptionCompat description, Map<?, ?> extras) {
+        if (extras == null || extras.isEmpty()) {
+            return description;
+        }
+        final Bundle extrasBundle = new Bundle();
+        if (description.getExtras() != null) {
+            extrasBundle.putAll(description.getExtras());
+        }
+        extrasBundle.putAll(mapToBundle(extras));
+        return new MediaDescriptionCompat.Builder()
+                .setTitle(description.getTitle())
+                .setSubtitle(description.getSubtitle())
+                .setDescription(description.getDescription())
+                .setIconBitmap(description.getIconBitmap())
+                .setIconUri(description.getIconUri())
+                .setMediaId(description.getMediaId())
+                .setMediaUri(description.getMediaUri())
+                .setExtras(extrasBundle).build();
+    }
+
+    private static MediaBrowserCompat.MediaItem rawToMediaItem(Map<?, ?> rawMediaItem) {
+        MediaMetadataCompat mediaMetadata = createMediaMetadata(rawMediaItem);
+        final MediaDescriptionCompat description = addExtrasToMediaDescription(mediaMetadata.getDescription(), (Map<?, ?>)rawMediaItem.get("extras"));
+        final Boolean playable = (Boolean)rawMediaItem.get("playable");
+        return  new MediaBrowserCompat.MediaItem(description, playable ? MediaBrowserCompat.MediaItem.FLAG_PLAYABLE : MediaBrowserCompat.MediaItem.FLAG_BROWSABLE);
+    }
+
     private static List<MediaSessionCompat.QueueItem> raw2queue(List<Map<?, ?>> rawQueue) {
         List<MediaSessionCompat.QueueItem> queue = new ArrayList<>();
         int i = 0;
         for (Map<?, ?> rawMediaItem : rawQueue) {
             MediaMetadataCompat mediaMetadata = createMediaMetadata(rawMediaItem);
-            MediaDescriptionCompat description = mediaMetadata.getDescription();
+            MediaDescriptionCompat description = addExtrasToMediaDescription(mediaMetadata.getDescription(), (Map<?, ?>)rawMediaItem.get("extras"));
             queue.add(new MediaSessionCompat.QueueItem(description, i));
             i++;
         }

--- a/audio_service/pubspec.yaml
+++ b/audio_service/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_service
 description: Flutter plugin to play audio in the background while the screen is off.
-version: 0.18.5
+version: 0.18.6
 homepage: https://github.com/ryanheise/audio_service/tree/master/audio_service
 
 environment:


### PR DESCRIPTION
- **Updated androidx.media** to support new MediaItem metadata like [DESCRIPTION_EXTRAS_KEY_COMPLETION_PERCENTAGE](https://developer.android.com/reference/androidx/media/utils/MediaConstants#DESCRIPTION_EXTRAS_KEY_COMPLETION_PERCENTAGE)
- **Propagate dart's mediaItem's extras to `MediaItemCompat` description's extras.** Until now the `MediaItemCompat` was created using the `MediaMedataCompat` description. However, when building a `MediaMetadataCompat` instance, it doesn't pass all the extras to its `MediaDescriptionCompat` object.
- **Update the progress bar in the browse view as content is playing**: Set the [PLAYBACK_STATE_EXTRAS_KEY_MEDIA_ID](https://developer.android.com/reference/androidx/media/utils/MediaConstants#PLAYBACK_STATE_EXTRAS_KEY_MEDIA_ID) on the playback state so the MediaService knows about which item is currently playing and updates the Browse view accordingly.

#941 

## Pre-launch Checklist

- [X] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [X] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [X] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I ran `dart analyze`.
- [X] I ran `dart format`.
- [X] I ran `flutter test` and all tests are passing.

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
