### PR TITLE
Adding image url as a media item param

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.18.8
+* added `imageUrl` param to `MediaItem` class.
+
 ## 0.18.7
 
 * Fix stopForeground bug on Android SDK < 24.

--- a/audio_service/lib/audio_service.dart
+++ b/audio_service/lib/audio_service.dart
@@ -621,6 +621,11 @@ class MediaItem {
   /// The rating of the media item.
   final Rating? rating;
 
+  /// An optional imageUrl parameter useful for holding an image url.
+  /// Most useful when using just_audio where you need not store image as
+  /// an extra or artHeader param. 
+  final String? imageUrl;
+  
   /// A map of additional metadata for the media item.
   ///
   /// The values must be of type `int`, `String`, `bool` or `double`.
@@ -634,6 +639,7 @@ class MediaItem {
     required this.title,
     this.album,
     this.artist,
+    this.imageUrl,
     this.genre,
     this.duration,
     this.artUri,

--- a/audio_service/lib/audio_service.dart
+++ b/audio_service/lib/audio_service.dart
@@ -623,9 +623,9 @@ class MediaItem {
 
   /// An optional imageUrl parameter useful for holding an image url.
   /// Most useful when using just_audio where you need not store image as
-  /// an extra or artHeader param. 
+  /// an extra or artHeader param.
   final String? imageUrl;
-  
+
   /// A map of additional metadata for the media item.
   ///
   /// The values must be of type `int`, `String`, `bool` or `double`.

--- a/audio_service/pubspec.yaml
+++ b/audio_service/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_service
 description: Flutter plugin to play audio in the background while the screen is off.
-version: 0.18.7
+version: 0.18.8
 homepage: https://github.com/ryanheise/audio_service/tree/master/audio_service
 
 environment:


### PR DESCRIPTION
For `just_audio` package there are no suitable way to store an image url in the `MediaItem` class. This PR adds an additional nullable parameter that user can take advantage to store the image url for a particular music item


## Pre-launch Checklist

- [ ] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [ ] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [ ] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I ran `dart analyze`.
- [ ] I ran `dart format`.
- [ ] I ran `flutter test` and all tests are passing.

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
