### PR TITLE
Change FlutterActivity to FlutterFragmentActivity

### DIFF
--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServiceActivity.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServiceActivity.java
@@ -5,9 +5,10 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 
 import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.android.FlutterFragmentActivity;
 import io.flutter.embedding.engine.FlutterEngine;
 
-public class AudioServiceActivity extends FlutterActivity {
+public class AudioServiceActivity extends FlutterFragmentActivity {
     @Override
     public FlutterEngine provideFlutterEngine(@NonNull Context context) {
         return AudioServicePlugin.getFlutterEngine(context);


### PR DESCRIPTION
It doesn't make any difference in the app but is required for Stripe Payments as they require this (https://github.com/flutter-stripe/flutter_stripe#android at point 5).

I am making this PR as I think there is no way to change this otherwise and also this service requires us to use it's name in activity name instead of regular .MainActivity.

*If there's an open issue your PR is fixing, please list it here.*

## Pre-launch Checklist

- [x] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [x] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [ ] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I ran `dart analyze`.
- [x] I ran `dart format`.
- [x] I ran `flutter test` and all tests are passing.

P.S: Your should participate in the Hacktoberfest to get more contributions in your projects :)

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
