### PR TITLE
Fallback/default album art

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,11 +1,8 @@
 ## 0.18.8
 
-* Improve efficiency of mediaItem updates (@nt4f04uNd).
-
-## 0.18.7
-
 * Add `AudioService.setFallbackArt` that allows to specify a URI for a default album art (@nt4f04und)
 * Fix `loadThumbnailUri` key in extras never being used (@nt4f04und)
+* Art updates now will log all errors (@nt4f04und)
 * Update album art more efficiently, skip unnecessary updates (@nt4f04und)
 
 ## 0.18.7

--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## 0.18.7
 
+* Add `AudioService.setFallbackArt` that allows to specify a URI for a default album art (@nt4f04und)
+* Fix `loadThumbnailUri` key in extras never being used (@nt4f04und)
+* Update album art more efficiently, skip unnecessary updates (@nt4f04und)
+
+## 0.18.7
+
 * Fix stopForeground bug on Android SDK < 24.
 * Migrate to androidx.media 1.6.0 (@snipd-mikel)
 * Propagate MediaItem extras to Android Auto (@snipd-mikel)

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -24,6 +24,7 @@ import android.support.v4.media.RatingCompat;
 import android.support.v4.media.session.MediaControllerCompat;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
+import android.util.Log;
 import android.util.LruCache;
 import android.util.Size;
 import android.view.KeyEvent;
@@ -170,9 +171,12 @@ public class AudioService extends MediaBrowserServiceCompat {
 
     // This will rethrow any errors it will encounter during loading,
     // so that Dart side can detect that and load default art instead.
-    Bitmap loadArtBitmap(String artUriString, String loadThumbnailUri) {
-        Bitmap bitmap = artBitmapCache.get(artUriString);
-        if (bitmap != null) return bitmap;
+    Bitmap loadArtBitmap(String artUriString, String loadThumbnailUri, boolean updateFallbackArtCache) {
+        Bitmap bitmap = null;
+        if (!updateFallbackArtCache) {
+            Bitmap cachedBitmap = artBitmapCache.get(artUriString);
+            if (cachedBitmap != null) return cachedBitmap;
+        }
         // There are 3 cases handled by this function:
         //   1. content URI with openFileDescriptor
         //   2. content URI with loadThumbnail (when Android >= Q and specified by the config)
@@ -185,7 +189,7 @@ public class AudioService extends MediaBrowserServiceCompat {
                 if (loadThumbnailUri != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     Size defaultSize = new Size(192, 192);
                     bitmap = getContentResolver().loadThumbnail(
-                            artUri,
+                            Uri.parse(loadThumbnailUri),
                             new Size(config.artDownscaleWidth == -1
                                             ? defaultSize.getWidth()
                                             : config.artDownscaleWidth,
@@ -205,8 +209,10 @@ public class AudioService extends MediaBrowserServiceCompat {
                     }
                 }
             } catch (FileNotFoundException ex) {
+                Log.e("audio_service", "FileNotFoundException, artUriString=" + artUriString + ", loadThumbnailUri=" + loadThumbnailUri);
                 throw new RuntimeException(ex);
             } catch (IOException ex) {
+                Log.e("audio_service", "IOException, artUriString=" + artUriString + ", loadThumbnailUri=" + loadThumbnailUri);
                 throw new RuntimeException(ex);
             }
         }
@@ -724,17 +730,18 @@ public class AudioService extends MediaBrowserServiceCompat {
      *  - https://9to5google.com/2020/08/02/android-11-lockscreen-art/
      */
     synchronized void setMetadata(MediaMetadataCompat mediaMetadata) {
+        boolean updateFallbackArtCache = mediaMetadata.getString("updateFallbackArtCache") != null;
         String artCacheFilePath = mediaMetadata.getString("artCacheFile");
         if (artCacheFilePath != null) {
             // Load local files and network images, cached in files
-            artBitmap = loadArtBitmap(artCacheFilePath, null);
+            artBitmap = loadArtBitmap(artCacheFilePath, null, updateFallbackArtCache);
             mediaMetadata = putArtToMetadata(mediaMetadata);
         } else {
             // Load content:// URIs
             String artUri = mediaMetadata.getString(MediaMetadataCompat.METADATA_KEY_DISPLAY_ICON_URI);
             if (artUri != null && artUri.startsWith("content:")) {
                 String loadThumbnailUri = mediaMetadata.getString("loadThumbnailUri");
-                artBitmap = loadArtBitmap(artUri, loadThumbnailUri);
+                artBitmap = loadArtBitmap(artUri, loadThumbnailUri, updateFallbackArtCache);
                 mediaMetadata = putArtToMetadata(mediaMetadata);
             } else {
                 artBitmap = null;

--- a/audio_service/lib/audio_service.dart
+++ b/audio_service/lib/audio_service.dart
@@ -1001,17 +1001,20 @@ class AudioService {
     /// We potentially need to fetch the art before that.
     Future<void> _sendToPlatform(String? artCacheFilePath) async {
       final extras = mediaItem.extras;
+      final updateFallbackArtCache = useFallback && _updateFallbackArtCache;
       final platformMediaItem = mediaItem.copyWith(
         extras: <String, dynamic>{
           if (extras != null) ...extras,
           if (artCacheFilePath != null) 'artCacheFile': artCacheFilePath,
-          if (useFallback && _updateFallbackArtCache)
+          if (updateFallbackArtCache)
             'updateFallbackArtCache': '',
         },
       );
       await _platform.setMediaItem(
           SetMediaItemRequest(mediaItem: platformMediaItem._toMessage()));
-      _updateFallbackArtCache = false;
+      if (updateFallbackArtCache) {
+        _updateFallbackArtCache = false;
+      }
     }
 
     try {

--- a/audio_service/lib/audio_service.dart
+++ b/audio_service/lib/audio_service.dart
@@ -946,8 +946,10 @@ class AudioService {
     return handler;
   }
 
-  /// Allows to specify a URI for an album art and optionally headers that will be
+  /// Allows to specify a URI for an album art (and optionally headers) that will be
   /// used when [MediaItem.artUri] is null, or loading the art has failed.
+  ///
+  /// All schemes that are supported by [MediaItem.artUri] are supported here as well.
   static Future<void> setFallbackArt(
     Uri uri, {
     Map<String, String>? headers,

--- a/audio_service/lib/audio_service.dart
+++ b/audio_service/lib/audio_service.dart
@@ -970,16 +970,14 @@ class AudioService {
   static bool _updateFallbackArtCache = false;
   static Uri? _fallbackArtUri;
   static Map<String, String>? _fallbackArtHeaders;
-
   static Object? _artFetchOperationId;
   static Future<void> _observeMediaItem() async {
-    Object? _artFetchOperationId;
     _handler.mediaItem.listen((mediaItem) async {
       if (mediaItem == null) {
         return;
       }
       _updateMediaItem(mediaItem);
-    }
+    });
   }
 
   static Future<void> _updateMediaItem(MediaItem mediaItem) async {
@@ -1071,7 +1069,7 @@ class AudioService {
       } else {
         rethrow;
       }
-    });
+    }
   }
 
   static Future<void> _observeAndroidPlaybackInfo() async {


### PR DESCRIPTION
In the course of updates to art loading in https://github.com/ryanheise/audio_service/pull/805

Adds `AudioService.setFallbackArt` that automatically loads arts for all platforms using the existing refactored dart code.

Also fixes a bug with `loadThumbnailUri` where it was never used, which became obvious from another necessary change - reporting all errors from the native side to dart, to be able to fallback to default art.

Tested only on Android for now, this will need to be tested on other platforms

Fixes https://github.com/ryanheise/audio_service/issues/666
Fixes https://github.com/ryanheise/audio_service/issues/309

## Pre-launch Checklist

- [x] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [x] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [x] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I ran `dart analyze`.
- [x] I ran `dart format`.
- [x] I ran `flutter test` and all tests are passing.

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
