### PR TITLE
Fix/audio service filepath web issue

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.18.8
+* Fix the "Unsupported Operation" in the web platform caused by using dart.io
+
 ## 0.18.7
 
 * Fix stopForeground bug on Android SDK < 24.

--- a/audio_service/example/pubspec.yaml
+++ b/audio_service/example/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
 
+  cross_file: ^0.3.3+2
   path_provider: ^2.0.1
   audio_session: ^0.1.7
   just_audio: ^0.9.24

--- a/audio_service/lib/audio_service.dart
+++ b/audio_service/lib/audio_service.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:rxdart/rxdart.dart';
+import 'package:cross_file/cross_file.dart';
 
 AudioServicePlatform _platform = AudioServicePlatform.instance;
 
@@ -966,7 +967,13 @@ class AudioService {
             filePath = await _loadArtwork(mediaItem);
             // If we failed to download the art, abort.
             if (filePath == null) continue;
-            if (File(filePath).lengthSync() == 0) continue;
+            
+            if (kIsWeb) {
+              if (await XFile(filePath).length() == 0) continue;
+            }
+            else {
+              if (File(filePath).lengthSync() == 0) continue;
+            }
             // If we've already set a new media item, cancel this request.
             // XXX: Test this
             //if (mediaItem != _handler.mediaItem.value) continue;

--- a/audio_service/pubspec.yaml
+++ b/audio_service/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   flutter_cache_manager: ^3.0.1
   clock: ^1.1.0
   js: ^0.6.3
+  cross_file: ^0.3.3+2
   flutter:
     sdk: flutter
   flutter_web_plugins:


### PR DESCRIPTION
This PR fixes the "Unsupported Operation" error in the web platform caused by "_observeMediaItem" method in the audio_service.dart file.

*If there's an open issue your PR is fixing, please list it here.*
fixes https://github.com/ryanheise/audio_service/issues/980

## Pre-launch Checklist

- [X] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [X] My change is not breaking and lands in `minor` branch.
- [X] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I ran `dart analyze`.
- [X] I ran `dart format`.
- [X] I ran `flutter test` and all tests are passing.
