### PR TITLE
Fix inner audio handlers were unable to propagate errors when using SwitchAudioHandler #986

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.18.10
+
+* Fix inner audio handlers were unable to propagate errors when using SwitchAudioHandler (@dropout).
+
 ## 0.18.9
 
 * Fix cache bug in AudioServiceFragmentActivity (@Mordtimer).

--- a/audio_service/lib/audio_service.dart
+++ b/audio_service/lib/audio_service.dart
@@ -2003,37 +2003,37 @@ class SwitchAudioHandler extends CompositeAudioHandler {
     _customStateSubscription?.cancel();
     _inner = newInner;
     _playbackStateSubscription = inner.playbackState.listen(
-        _playbackState.add,
-        onError: _playbackState.addError,
+      _playbackState.add,
+      onError: _playbackState.addError,
     );
     _queueSubscription = inner.queue.listen(
-        _queue.add,
-        onError: _queue.addError,
+      _queue.add,
+      onError: _queue.addError,
     );
     _queueTitleSubscription = inner.queueTitle.listen(
-        _queueTitle.add,
-        onError: _queueTitle.addError,
+      _queueTitle.add,
+      onError: _queueTitle.addError,
     );
     // XXX: This only works in one direction.
     _mediaItemSubscription = inner.mediaItem.listen(
-        _mediaItem.add,
-        onError: _mediaItem.addError,
+      _mediaItem.add,
+      onError: _mediaItem.addError,
     );
     _androidPlaybackInfoSubscription = inner.androidPlaybackInfo.listen(
-        _androidPlaybackInfo.add,
-        onError: _androidPlaybackInfo.addError,
+      _androidPlaybackInfo.add,
+      onError: _androidPlaybackInfo.addError,
     );
     _ratingStyleSubscription = inner.ratingStyle.listen(
-        _ratingStyle.add,
-        onError: _ratingStyle.addError,
+      _ratingStyle.add,
+      onError: _ratingStyle.addError,
     );
     _customEventSubscription = inner.customEvent.listen(
-        _customEvent.add,
-        onError: _customEvent.addError,
+      _customEvent.add,
+      onError: _customEvent.addError,
     );
     _customStateSubscription = inner.customState.listen(
-        _customState.add,
-        onError: _customState.addError,
+      _customState.add,
+      onError: _customState.addError,
     );
   }
 }

--- a/audio_service/lib/audio_service.dart
+++ b/audio_service/lib/audio_service.dart
@@ -2002,16 +2002,39 @@ class SwitchAudioHandler extends CompositeAudioHandler {
     _customEventSubscription?.cancel();
     _customStateSubscription?.cancel();
     _inner = newInner;
-    _playbackStateSubscription = inner.playbackState.listen(_playbackState.add);
-    _queueSubscription = inner.queue.listen(_queue.add);
-    _queueTitleSubscription = inner.queueTitle.listen(_queueTitle.add);
+    _playbackStateSubscription = inner.playbackState.listen(
+        _playbackState.add,
+        onError: _playbackState.addError,
+    );
+    _queueSubscription = inner.queue.listen(
+        _queue.add,
+        onError: _queue.addError,
+    );
+    _queueTitleSubscription = inner.queueTitle.listen(
+        _queueTitle.add,
+        onError: _queueTitle.addError,
+    );
     // XXX: This only works in one direction.
-    _mediaItemSubscription = inner.mediaItem.listen(_mediaItem.add);
-    _androidPlaybackInfoSubscription =
-        inner.androidPlaybackInfo.listen(_androidPlaybackInfo.add);
-    _ratingStyleSubscription = inner.ratingStyle.listen(_ratingStyle.add);
-    _customEventSubscription = inner.customEvent.listen(_customEvent.add);
-    _customStateSubscription = inner.customState.listen(_customState.add);
+    _mediaItemSubscription = inner.mediaItem.listen(
+        _mediaItem.add,
+        onError: _mediaItem.addError,
+    );
+    _androidPlaybackInfoSubscription = inner.androidPlaybackInfo.listen(
+        _androidPlaybackInfo.add,
+        onError: _androidPlaybackInfo.addError,
+    );
+    _ratingStyleSubscription = inner.ratingStyle.listen(
+        _ratingStyle.add,
+        onError: _ratingStyle.addError,
+    );
+    _customEventSubscription = inner.customEvent.listen(
+        _customEvent.add,
+        onError: _customEvent.addError,
+    );
+    _customStateSubscription = inner.customState.listen(
+        _customState.add,
+        onError: _customState.addError,
+    );
   }
 }
 

--- a/audio_service/pubspec.yaml
+++ b/audio_service/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_service
 description: Flutter plugin to play audio in the background while the screen is off.
-version: 0.18.9
+version: 0.18.10
 homepage: https://github.com/ryanheise/audio_service/tree/master/audio_service
 
 environment:

--- a/audio_service/test/switch_audio_handler_test.dart
+++ b/audio_service/test/switch_audio_handler_test.dart
@@ -5,20 +5,16 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   group('SwitchAudioHandler:', () {
     test('Can forward errors from inner audio handlers', () {
-
       InnerAudioHandlerA innerAudioHandlerA = InnerAudioHandlerA();
       InnerAudioHandlerB innerAudioHandlerB = InnerAudioHandlerB();
 
-      _TestSwitchAudioHandler switchAudioHandler = _TestSwitchAudioHandler(
-        innerAudioHandlerA,
-        innerAudioHandlerB
-      );
+      _TestSwitchAudioHandler switchAudioHandler =
+          _TestSwitchAudioHandler(innerAudioHandlerA, innerAudioHandlerB);
 
       DateTime updateTime = DateTime.now();
 
-      switchAudioHandler.customAction('switchToHandler', <String, dynamic>{
-        'handlerId': InnerAudioHandlerB.handlerId
-      });
+      switchAudioHandler.customAction('switchToHandler',
+          <String, dynamic>{'handlerId': InnerAudioHandlerB.handlerId});
 
       innerAudioHandlerB.playbackState.add(PlaybackState(
         processingState: AudioProcessingState.loading,
@@ -38,27 +34,20 @@ void main() {
           emitsError('Error occurred'),
         ]),
       );
-
     });
   });
 }
 
 class _TestSwitchAudioHandler extends SwitchAudioHandler {
-
   final InnerAudioHandlerA _innerAudioHandlerA;
   final InnerAudioHandlerB _innerAudioHandlerB;
 
-  _TestSwitchAudioHandler(
-    this._innerAudioHandlerA,
-    this._innerAudioHandlerB
-  ) : super(_innerAudioHandlerA);
+  _TestSwitchAudioHandler(this._innerAudioHandlerA, this._innerAudioHandlerB)
+      : super(_innerAudioHandlerA);
 
   @override
-  Future<dynamic> customAction(
-      String name,
-      [Map<String, dynamic>? extras]
-      ) async {
-
+  Future<dynamic> customAction(String name,
+      [Map<String, dynamic>? extras]) async {
     switch (name) {
       case 'switchToHandler':
         stop();
@@ -77,9 +66,7 @@ class _TestSwitchAudioHandler extends SwitchAudioHandler {
       default:
         return super.customAction(name, extras);
     }
-
   }
-
 }
 
 class InnerAudioHandlerA extends BaseAudioHandler {

--- a/audio_service/test/switch_audio_handler_test.dart
+++ b/audio_service/test/switch_audio_handler_test.dart
@@ -1,0 +1,91 @@
+import 'package:audio_service/audio_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  group('SwitchAudioHandler:', () {
+    test('Can forward errors from inner audio handlers', () {
+
+      InnerAudioHandlerA innerAudioHandlerA = InnerAudioHandlerA();
+      InnerAudioHandlerB innerAudioHandlerB = InnerAudioHandlerB();
+
+      _TestSwitchAudioHandler switchAudioHandler = _TestSwitchAudioHandler(
+        innerAudioHandlerA,
+        innerAudioHandlerB
+      );
+
+      DateTime updateTime = DateTime.now();
+
+      switchAudioHandler.customAction('switchToHandler', <String, dynamic>{
+        'handlerId': InnerAudioHandlerB.handlerId
+      });
+
+      innerAudioHandlerB.playbackState.add(PlaybackState(
+        processingState: AudioProcessingState.loading,
+        updateTime: updateTime,
+      ));
+
+      innerAudioHandlerB.playbackState.addError('Error occurred');
+
+      expectLater(
+        switchAudioHandler.playbackState,
+        emitsInOrder(<dynamic>[
+          emits(anything),
+          PlaybackState(
+            processingState: AudioProcessingState.loading,
+            updateTime: updateTime,
+          ),
+          emitsError('Error occurred'),
+        ]),
+      );
+
+    });
+  });
+}
+
+class _TestSwitchAudioHandler extends SwitchAudioHandler {
+
+  final InnerAudioHandlerA _innerAudioHandlerA;
+  final InnerAudioHandlerB _innerAudioHandlerB;
+
+  _TestSwitchAudioHandler(
+    this._innerAudioHandlerA,
+    this._innerAudioHandlerB
+  ) : super(_innerAudioHandlerA);
+
+  @override
+  Future<dynamic> customAction(
+      String name,
+      [Map<String, dynamic>? extras]
+      ) async {
+
+    switch (name) {
+      case 'switchToHandler':
+        stop();
+
+        String handlerId = extras!['handlerId'] as String;
+
+        if (handlerId == InnerAudioHandlerA.handlerId) {
+          inner = _innerAudioHandlerA;
+        }
+
+        if (handlerId == InnerAudioHandlerB.handlerId) {
+          inner = _innerAudioHandlerB;
+        }
+
+        return null;
+      default:
+        return super.customAction(name, extras);
+    }
+
+  }
+
+}
+
+class InnerAudioHandlerA extends BaseAudioHandler {
+  static const handlerId = 'A';
+}
+
+class InnerAudioHandlerB extends BaseAudioHandler {
+  static const handlerId = 'B';
+}


### PR DESCRIPTION
When using SwitchAudioHandlers, inner AudioHandler's were unable to propagate errors to SwitchAudioHandler

[#986](https://github.com/ryanheise/audio_service/issues/986)

## Pre-launch Checklist

- [x] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [x] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [x] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I ran `dart analyze`.
- [x] I ran `dart format`.
- [x] I ran `flutter test` and all tests are passing.
