### PR TITLE
Add setFallbackArt to specify default art

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.18.10
+
+* Add `AudioService.setFallbackArt` that allows to specify a URI for a default album art (@nt4f04und)
+* Fix `loadThumbnailUri` key in extras never being used (@nt4f04und)
+* Art updates now will log all errors (@nt4f04und)
+
 ## 0.18.9
 
 * Fix cache bug in AudioServiceFragmentActivity (@Mordtimer).

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -24,6 +24,7 @@ import android.support.v4.media.RatingCompat;
 import android.support.v4.media.session.MediaControllerCompat;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
+import android.util.Log;
 import android.util.LruCache;
 import android.util.Size;
 import android.view.KeyEvent;
@@ -168,79 +169,81 @@ public class AudioService extends MediaBrowserServiceCompat {
         return mediaMetadataCache.get(mediaId);
     }
 
-    Bitmap loadArtBitmap(String artUriString, String loadThumbnailUri) {
-        Bitmap bitmap = artBitmapCache.get(artUriString);
-        if (bitmap != null) return bitmap;
-        try {
-            // There are 3 cases handled by this function:
-            //   1. content URI with openFileDescriptor
-            //   2. content URI with loadThumbnail (when Android >= Q and specified by the config)
-            //   3. not content URI - loading from the file, or cache file created by the Dart side
-            Uri artUri = Uri.parse(artUriString);
-            boolean usesContentScheme = "content".equals(artUri.getScheme());
-            FileDescriptor fileDescriptor = null;
-            if (usesContentScheme) {
-                try {
-                    if (loadThumbnailUri != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                        Size defaultSize = new Size(192, 192);
-                        bitmap = getContentResolver().loadThumbnail(
-                                artUri,
-                                new Size(config.artDownscaleWidth == -1
-                                                ? defaultSize.getWidth()
-                                                : config.artDownscaleWidth,
-                                        config.artDownscaleHeight == -1
-                                                ? defaultSize.getHeight()
-                                                : config.artDownscaleHeight),
-                                null);
-                        if (bitmap == null) {
-                            return null;
-                        }
-                    } else {
-                        ParcelFileDescriptor parcelFileDescriptor = getContentResolver().openFileDescriptor(artUri, "r");
-                        if (parcelFileDescriptor != null) {
-                            fileDescriptor = parcelFileDescriptor.getFileDescriptor();
-                        } else {
-                            return null;
-                        }
-                    }
-                } catch (FileNotFoundException ex) {
-                    return null;
-                } catch (IOException ex) {
-                    return null;
-                }
-            }
-            // Decode the image ourselves for scenarios 1 and 3 (see the comment above).
-            if (!usesContentScheme || fileDescriptor != null) {
-                if (config.artDownscaleWidth != -1) {
-                    BitmapFactory.Options options = new BitmapFactory.Options();
-                    options.inJustDecodeBounds = true;
-                    if (fileDescriptor != null) {
-                        BitmapFactory.decodeFileDescriptor(fileDescriptor, null, options);
-                    } else {
-                        BitmapFactory.decodeFile(artUri.getPath(), options);
-                    }
-                    options.inSampleSize = calculateInSampleSize(options, config.artDownscaleWidth, config.artDownscaleHeight);
-                    options.inJustDecodeBounds = false;
-
-                    if (fileDescriptor != null) {
-                        bitmap = BitmapFactory.decodeFileDescriptor(fileDescriptor, null, options);
-                    } else {
-                        bitmap = BitmapFactory.decodeFile(artUri.getPath(), options);
+    // This will rethrow any errors it will encounter during loading,
+    // so that Dart side can detect that and load default art instead.
+    Bitmap loadArtBitmap(String artUriString, String loadThumbnailUri, boolean updateFallbackArtCache) {
+        Bitmap bitmap = null;
+        if (!updateFallbackArtCache) {
+            Bitmap cachedBitmap = artBitmapCache.get(artUriString);
+            if (cachedBitmap != null) return cachedBitmap;
+        }
+        // There are 3 cases handled by this function:
+        //   1. content URI with openFileDescriptor
+        //   2. content URI with loadThumbnail (when Android >= Q and specified by the config)
+        //   3. not content URI - loading from the file, or cache file created by the Dart side
+        Uri artUri = Uri.parse(artUriString);
+        boolean usesContentScheme = "content".equals(artUri.getScheme());
+        FileDescriptor fileDescriptor = null;
+        if (usesContentScheme) {
+            try {
+                if (loadThumbnailUri != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    Size defaultSize = new Size(192, 192);
+                    bitmap = getContentResolver().loadThumbnail(
+                            Uri.parse(loadThumbnailUri),
+                            new Size(config.artDownscaleWidth == -1
+                                            ? defaultSize.getWidth()
+                                            : config.artDownscaleWidth,
+                                    config.artDownscaleHeight == -1
+                                            ? defaultSize.getHeight()
+                                            : config.artDownscaleHeight),
+                            null);
+                    if (bitmap == null) {
+                        return null;
                     }
                 } else {
-                    if (fileDescriptor != null) {
-                        bitmap = BitmapFactory.decodeFileDescriptor(fileDescriptor);
+                    ParcelFileDescriptor parcelFileDescriptor = getContentResolver().openFileDescriptor(artUri, "r");
+                    if (parcelFileDescriptor != null) {
+                        fileDescriptor = parcelFileDescriptor.getFileDescriptor();
                     } else {
-                        bitmap = BitmapFactory.decodeFile(artUri.getPath());
+                        return null;
                     }
                 }
+            } catch (FileNotFoundException ex) {
+                Log.e("audio_service", "FileNotFoundException, artUriString=" + artUriString + ", loadThumbnailUri=" + loadThumbnailUri);
+                throw new RuntimeException(ex);
+            } catch (IOException ex) {
+                Log.e("audio_service", "IOException, artUriString=" + artUriString + ", loadThumbnailUri=" + loadThumbnailUri);
+                throw new RuntimeException(ex);
             }
-            artBitmapCache.put(artUriString, bitmap);
-            return bitmap;
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
         }
+        // Decode the image ourselves for scenarios 1 and 3 (see the comment above).
+        if (!usesContentScheme || fileDescriptor != null) {
+            if (config.artDownscaleWidth != -1) {
+                BitmapFactory.Options options = new BitmapFactory.Options();
+                options.inJustDecodeBounds = true;
+                if (fileDescriptor != null) {
+                    BitmapFactory.decodeFileDescriptor(fileDescriptor, null, options);
+                } else {
+                    BitmapFactory.decodeFile(artUri.getPath(), options);
+                }
+                options.inSampleSize = calculateInSampleSize(options, config.artDownscaleWidth, config.artDownscaleHeight);
+                options.inJustDecodeBounds = false;
+
+                if (fileDescriptor != null) {
+                    bitmap = BitmapFactory.decodeFileDescriptor(fileDescriptor, null, options);
+                } else {
+                    bitmap = BitmapFactory.decodeFile(artUri.getPath(), options);
+                }
+            } else {
+                if (fileDescriptor != null) {
+                    bitmap = BitmapFactory.decodeFileDescriptor(fileDescriptor);
+                } else {
+                    bitmap = BitmapFactory.decodeFile(artUri.getPath());
+                }
+            }
+        }
+        artBitmapCache.put(artUriString, bitmap);
+        return bitmap;
     }
 
     private static int calculateInSampleSize(BitmapFactory.Options options, int reqWidth, int reqHeight) {
@@ -727,17 +730,18 @@ public class AudioService extends MediaBrowserServiceCompat {
      *  - https://9to5google.com/2020/08/02/android-11-lockscreen-art/
      */
     synchronized void setMetadata(MediaMetadataCompat mediaMetadata) {
+        boolean updateFallbackArtCache = mediaMetadata.getString("updateFallbackArtCache") != null;
         String artCacheFilePath = mediaMetadata.getString("artCacheFile");
         if (artCacheFilePath != null) {
             // Load local files and network images, cached in files
-            artBitmap = loadArtBitmap(artCacheFilePath, null);
+            artBitmap = loadArtBitmap(artCacheFilePath, null, updateFallbackArtCache);
             mediaMetadata = putArtToMetadata(mediaMetadata);
         } else {
             // Load content:// URIs
             String artUri = mediaMetadata.getString(MediaMetadataCompat.METADATA_KEY_DISPLAY_ICON_URI);
             if (artUri != null && artUri.startsWith("content:")) {
                 String loadThumbnailUri = mediaMetadata.getString("loadThumbnailUri");
-                artBitmap = loadArtBitmap(artUri, loadThumbnailUri);
+                artBitmap = loadArtBitmap(artUri, loadThumbnailUri, updateFallbackArtCache);
                 mediaMetadata = putArtToMetadata(mediaMetadata);
             } else {
                 artBitmap = null;

--- a/audio_service/lib/audio_service.dart
+++ b/audio_service/lib/audio_service.dart
@@ -689,6 +689,7 @@ abstract class MediaItemCopyWith {
     String? genre,
     Duration? duration,
     Uri? artUri,
+    Map<String, String>? artHeaders,
     bool? playable,
     String? displayTitle,
     String? displaySubtitle,
@@ -717,6 +718,7 @@ class _MediaItemCopyWith extends MediaItemCopyWith {
     Object? genre = _fakeNull,
     Object? duration = _fakeNull,
     Object? artUri = _fakeNull,
+    Object? artHeaders = _fakeNull,
     Object? playable = _fakeNull,
     Object? displayTitle = _fakeNull,
     Object? displaySubtitle = _fakeNull,
@@ -733,6 +735,9 @@ class _MediaItemCopyWith extends MediaItemCopyWith {
         duration:
             duration == _fakeNull ? value.duration : duration as Duration?,
         artUri: artUri == _fakeNull ? value.artUri : artUri as Uri?,
+        artHeaders: artHeaders == _fakeNull
+            ? value.artHeaders
+            : artHeaders as Map<String, String>?,
         playable: playable == _fakeNull ? value.playable : playable as bool?,
         displayTitle: displayTitle == _fakeNull
             ? value.displayTitle
@@ -881,7 +886,8 @@ class AudioService {
   static BaseCacheManager? _cacheManager;
 
   static late AudioServiceConfig _config;
-  static late AudioHandler _handler;
+  static AudioHandler get _handler => __handler!;
+  static AudioHandler? __handler;
 
   /// The current configuration.
   static AudioServiceConfig get config => _config;
@@ -916,7 +922,7 @@ class AudioService {
   /// correct Service or Activity in your `AndroidManifest.xml` file or if your
   /// Activity does not provide the correct `FlutterEngine`.
   static Future<T> init<T extends AudioHandler>({
-    required T Function() builder,
+    required FutureOr<T> Function() builder,
     AudioServiceConfig? config,
     BaseCacheManager? cacheManager,
   }) async {
@@ -930,8 +936,8 @@ class AudioService {
     _platform.setHandlerCallbacks(callbacks);
     await _platform.configure(ConfigureRequest(config: config._toMessage()));
     _config = config;
-    final handler = builder();
-    _handler = handler;
+    final handler = await builder();
+    __handler = handler;
     callbacks.setHandler(handler);
 
     _observeMediaItem();
@@ -942,35 +948,83 @@ class AudioService {
     return handler;
   }
 
+  /// Allows to specify a URI for an album art (and optionally headers) that will be
+  /// used when [MediaItem.artUri] is null, or loading the art has failed.
+  ///
+  /// All schemes that are supported by [MediaItem.artUri] are supported here as well.
+  static Future<void> setFallbackArt(
+    Uri uri, {
+    Map<String, String>? headers,
+  }) async {
+    assert(_cacheManager != null, 'Call AudioService.init first');
+    _updateFallbackArtCache = true;
+    _fallbackArtUri = uri;
+    _fallbackArtHeaders = headers;
+    if (__handler != null) {
+      final currentMediaItem = __handler!.mediaItem.value;
+      if (currentMediaItem != null) {
+        await AudioService.cacheManager.removeFile(uri.toString());
+        await _updateMediaItem(currentMediaItem);
+      }
+    }
+  }
+
+  static bool _updateFallbackArtCache = false;
+  static Uri? _fallbackArtUri;
+  static Map<String, String>? _fallbackArtHeaders;
+  static Object? _artFetchOperationId;
   static Future<void> _observeMediaItem() async {
-    Object? _artFetchOperationId;
     _handler.mediaItem.listen((mediaItem) async {
       if (mediaItem == null) {
         return;
       }
-      final operationId = Object();
-      _artFetchOperationId = operationId;
-      final artUri = mediaItem.artUri;
-      if (artUri == null || artUri.scheme == 'content') {
-        _platform.setMediaItem(
-            SetMediaItemRequest(mediaItem: mediaItem._toMessage()));
-      } else {
-        /// Sends media item to the platform.
-        /// We potentially need to fetch the art before that.
-        Future<void> _sendToPlatform(String? filePath) async {
-          final extras = mediaItem.extras;
-          final platformMediaItem = mediaItem.copyWith(
-            extras: <String, dynamic>{
-              if (extras != null) ...extras,
-              'artCacheFile': filePath,
-            },
-          );
-          await _platform.setMediaItem(
-              SetMediaItemRequest(mediaItem: platformMediaItem._toMessage()));
-        }
+      _updateMediaItem(mediaItem);
+    });
+  }
 
+  static Future<void> _updateMediaItem(MediaItem mediaItem) async {
+    final operationId = Object();
+    _artFetchOperationId = operationId;
+
+    final mediaItemArtUri = mediaItem.artUri;
+    final mediaItemArtHeaders = mediaItem.artHeaders;
+    final useFallback = mediaItemArtUri == null && _fallbackArtUri != null;
+    final Uri? artUri;
+    final Map<String, String>? artHeaders;
+    if (useFallback) {
+      artUri = _fallbackArtUri!;
+      artHeaders = _fallbackArtHeaders;
+    } else {
+      artUri = mediaItemArtUri;
+      artHeaders = mediaItemArtHeaders;
+    }
+
+    /// Sends media item to the platform.
+    /// We potentially need to fetch the art before that.
+    Future<void> _sendToPlatform(String? artCacheFilePath) async {
+      final extras = mediaItem.extras;
+      final updateFallbackArtCache = useFallback && _updateFallbackArtCache;
+      final platformMediaItem = mediaItem.copyWith(
+        extras: <String, dynamic>{
+          if (extras != null) ...extras,
+          if (artCacheFilePath != null) 'artCacheFile': artCacheFilePath,
+          if (updateFallbackArtCache)
+            'updateFallbackArtCache': '',
+        },
+      );
+      await _platform.setMediaItem(
+          SetMediaItemRequest(mediaItem: platformMediaItem._toMessage()));
+      if (updateFallbackArtCache) {
+        _updateFallbackArtCache = false;
+      }
+    }
+
+    try {
+      if (artUri == null || artUri.scheme == 'content') {
+        await _sendToPlatform(null);
+      } else {
         if (artUri.scheme == 'file') {
-          _sendToPlatform(artUri.toFilePath());
+          await _sendToPlatform(artUri.toFilePath());
         } else {
           // Try to load a cached file from memory.
           final fileInfo =
@@ -982,7 +1036,7 @@ class AudioService {
 
           if (filePath != null) {
             // If we successfully downloaded the art call to platform.
-            _sendToPlatform(filePath);
+            await _sendToPlatform(filePath);
           } else {
             // We haven't fetched the art yet, so show the metadata now, and again
             // after we load the art.
@@ -992,18 +1046,35 @@ class AudioService {
               return;
             }
             // Load the art.
-            final loadedFilePath = await _loadArtwork(mediaItem);
+            final loadedFilePath = await _loadArtwork(
+              artUri,
+              artHeaders,
+            );
             if (operationId != _artFetchOperationId) {
               return;
             }
             // If we successfully downloaded the art, call to platform.
             if (loadedFilePath != null) {
-              _sendToPlatform(loadedFilePath);
+              await _sendToPlatform(loadedFilePath);
             }
           }
         }
       }
-    });
+    } catch (e) {
+      if (operationId != _artFetchOperationId) {
+        return;
+      }
+      if (!useFallback && _fallbackArtUri != null) {
+        // Try to use fallback, if the actual art loading has failed for some reason.
+        _reportArtworkFallback(artUri, artHeaders);
+        await _updateMediaItem(mediaItem.copyWith(
+          artUri: null,
+          artHeaders: null,
+        ));
+      } else {
+        rethrow;
+      }
+    }
   }
 
   static Future<void> _observeAndroidPlaybackInfo() async {
@@ -1133,29 +1204,66 @@ class AudioService {
 
   static Future<void> _loadAllArtwork(List<MediaItem> queue) async {
     for (var mediaItem in queue) {
-      await _loadArtwork(mediaItem);
+      await _loadArtwork(
+        mediaItem.artUri,
+        mediaItem.artHeaders,
+      );
     }
   }
 
-  static Future<String?> _loadArtwork(MediaItem mediaItem) async {
+  static void _reportArtworkFallback(
+    Uri? artUri,
+    Map<String, String>? artHeaders,
+  ) {
+    debugPrint(
+      '[audio_service] art_loading: failed to load song art artUri=$artUri, '
+      'falling back to using default art artUri=$_fallbackArtUri',
+    );
+  }
+
+  static void _reportArtworkError(Object exception, StackTrace stackTrace) {
+    debugPrint('Error loading artUri: $exception\n$stackTrace');
+  }
+
+  static Future<String?> _loadArtwork(
+    Uri? mediaItemArtUri,
+    Map<String, String>? mediaItemArtHeaders,
+  ) async {
+    final useFallback = mediaItemArtUri == null && _fallbackArtUri != null;
+    final Uri? artUri;
+    final Map<String, String>? artHeaders;
+    if (useFallback) {
+      artUri = _fallbackArtUri!;
+      artHeaders = _fallbackArtHeaders;
+    } else {
+      artUri = mediaItemArtUri;
+      artHeaders = mediaItemArtHeaders;
+    }
     try {
-      final artUri = mediaItem.artUri;
       if (artUri != null) {
         if (artUri.scheme == 'file') {
           return artUri.toFilePath();
         } else {
-          final headers = mediaItem.artHeaders;
-          final file = headers != null
-              ? await cacheManager.getSingleFile(mediaItem.artUri!.toString(),
-                  headers: headers)
-              : await cacheManager.getSingleFile(mediaItem.artUri!.toString());
+          final file = artHeaders != null
+              ? await cacheManager.getSingleFile(
+                  artUri.toString(),
+                  headers: artHeaders,
+                )
+              : await cacheManager.getSingleFile(artUri.toString());
           return file.path;
         }
       }
     } catch (e, st) {
-      // TODO: handle this somehow?
-      // ignore: avoid_print
-      print('Error loading artUri: $e\n$st');
+      if (!useFallback && _fallbackArtUri != null) {
+        // Try to use fallback, if the actual art loading has failed for some reason.
+        _reportArtworkFallback(artUri, artHeaders);
+        return await _loadArtwork(
+          null,
+          null,
+        );
+      } else {
+        _reportArtworkError(e, st);
+      }
     }
     return null;
   }

--- a/audio_service/pubspec.yaml
+++ b/audio_service/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_service
 description: Flutter plugin to play audio in the background while the screen is off.
-version: 0.18.9
+version: 0.18.10
 homepage: https://github.com/ryanheise/audio_service/tree/master/audio_service
 
 environment:


### PR DESCRIPTION
Adds `AudioService.setFallbackArt` that automatically loads arts for all platforms using the existing refactored dart code.

Also fixes a bug with `loadThumbnailUri` where it was never used, which became obvious from another necessary change - reporting all errors from the native side to dart, to be able to fallback to default art.

Tested only on Android for now, this will need to be tested on other platforms

Fixes https://github.com/ryanheise/audio_service/issues/666
Fixes https://github.com/ryanheise/audio_service/issues/309

I wrote this PR because I needed this in my app. You can see how I'm using this API there if you want, there's also a video https://github.com/nt4f04uNd/sweyer/pull/80

https://user-images.githubusercontent.com/39104740/213883470-255b72e3-0378-42e7-82d6-bcb84e153fd4.mp4



## Pre-launch Checklist

- [x] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [x] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [x] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I ran `dart analyze`.
- [x] I ran `dart format`.
- [x] I ran `flutter test` and all tests are passing.

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
