### PR TITLE
Add new optional cacheKeyResolver

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.18.10
+
+* Add optional `cacheKeyResolver` for MediaItem art (@austinried).
+
 ## 0.18.9
 
 * Fix cache bug in AudioServiceFragmentActivity (@Mordtimer).

--- a/audio_service/lib/audio_service.dart
+++ b/audio_service/lib/audio_service.dart
@@ -880,9 +880,9 @@ class AudioService {
   static BaseCacheManager get cacheManager => _cacheManager!;
   static BaseCacheManager? _cacheManager;
 
-  /// The method used to generate the cache key for interacting with artwork in
-  /// the cache.
-  /// Defaults to [MediaItem.artUri.toString].
+  /// The method used to generate the cache key for interacting with a
+  /// MedieItem's artwork in the cache manager.
+  /// Defaults to using [MediaItem.artUri.toString] as the cache key.
   static FutureOr<String> Function(MediaItem mediaItem) get cacheKeyResolver =>
       _cacheKeyResolver!;
   static FutureOr<String> Function(MediaItem mediaItem)? _cacheKeyResolver;

--- a/audio_service/lib/audio_service.dart
+++ b/audio_service/lib/audio_service.dart
@@ -880,6 +880,13 @@ class AudioService {
   static BaseCacheManager get cacheManager => _cacheManager!;
   static BaseCacheManager? _cacheManager;
 
+  /// The method used to generate the cache key for interacting with artwork in
+  /// the cache.
+  /// Defaults to [MediaItem.artUri.toString].
+  static FutureOr<String> Function(MediaItem mediaItem) get cacheKeyResolver =>
+      _cacheKeyResolver!;
+  static FutureOr<String> Function(MediaItem mediaItem)? _cacheKeyResolver;
+
   static late AudioServiceConfig _config;
   static late AudioHandler _handler;
 
@@ -919,6 +926,7 @@ class AudioService {
     required T Function() builder,
     AudioServiceConfig? config,
     BaseCacheManager? cacheManager,
+    FutureOr<String> Function(MediaItem mediaItem)? cacheKeyResolver,
   }) async {
     assert(_cacheManager == null);
     config ??= const AudioServiceConfig();
@@ -926,6 +934,8 @@ class AudioService {
     assert(config.rewindInterval > Duration.zero);
     WidgetsFlutterBinding.ensureInitialized();
     _cacheManager = (cacheManager ??= DefaultCacheManager());
+    _cacheKeyResolver = (cacheKeyResolver ??=
+        (MediaItem mediaItem) => mediaItem.artUri.toString());
     final callbacks = _HandlerCallbacks();
     _platform.setHandlerCallbacks(callbacks);
     await _platform.configure(ConfigureRequest(config: config._toMessage()));
@@ -973,8 +983,8 @@ class AudioService {
           _sendToPlatform(artUri.toFilePath());
         } else {
           // Try to load a cached file from memory.
-          final fileInfo =
-              await cacheManager.getFileFromMemory(artUri.toString());
+          final fileInfo = await cacheManager
+              .getFileFromMemory(await cacheKeyResolver(mediaItem));
           final filePath = fileInfo?.file.path;
           if (operationId != _artFetchOperationId) {
             return;
@@ -1147,8 +1157,9 @@ class AudioService {
           final headers = mediaItem.artHeaders;
           final file = headers != null
               ? await cacheManager.getSingleFile(mediaItem.artUri!.toString(),
-                  headers: headers)
-              : await cacheManager.getSingleFile(mediaItem.artUri!.toString());
+                  key: await cacheKeyResolver(mediaItem), headers: headers)
+              : await cacheManager.getSingleFile(mediaItem.artUri!.toString(),
+                  key: await cacheKeyResolver(mediaItem));
           return file.path;
         }
       }

--- a/audio_service/pubspec.yaml
+++ b/audio_service/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_service
 description: Flutter plugin to play audio in the background while the screen is off.
-version: 0.18.9
+version: 0.18.10
 homepage: https://github.com/ryanheise/audio_service/tree/master/audio_service
 
 environment:


### PR DESCRIPTION
This PR adds an optional parameter to `AudioService.init()` that allows specifying a `cacheKeyResolver` function which specifies how a cache key is resolved for a given `MediaItem`'s art with the cache manager. If no method is specified, the current behavior is kept (the URL is used as the cache key).

This new method allow custom cache key implementations to better support situations where the URL may not be suitable as a cache key. It also brings parity with other packages like `cached_network_image` which also allows specifying a custom cache key, so if you're using the same cache manager across both libraries you can also use the same cache keys. 

Fixes #1001.

## Pre-launch Checklist

- [x] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [x] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [x] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I ran `dart analyze`.
- [x] I ran `dart format`.
- [x] I ran `flutter test` and all tests are passing.