### PR TITLE
Stop service with task

### DIFF
--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -806,6 +806,7 @@ public class AudioService extends MediaBrowserServiceCompat {
             listener.onTaskRemoved();
         }
         super.onTaskRemoved(rootIntent);
+        this.stopSelf();
     }
 
     public class MediaSessionCallback extends MediaSessionCompat.Callback {

--- a/audio_service/example/android/app/src/main/AndroidManifest.xml
+++ b/audio_service/example/android/app/src/main/AndroidManifest.xml
@@ -40,6 +40,7 @@
             android:name="com.ryanheise.audioservice.AudioService"
             android:foregroundServiceType="mediaPlayback"
             android:exported="true"
+            android:stopWithTask="true"
             tools:ignore="Instantiatable">
             <intent-filter>
                 <action android:name="android.media.browse.MediaBrowserService" />


### PR DESCRIPTION
Hi,

Thanks for such a great plugin but i needed one change in my implementation.

The thing is we need to remove notification and stop service if my app is removed from recent by user so i have read that we can do this by adding ```android:stopWithTask="true"``` in the ```<service>``` tag of ```AndroidManifest.xml``` and then we can stop the service by calling ```this.stopSelf();``` in ```onTaskRemoved``` method.

The above code reference i found on the below link

https://stackoverflow.com/questions/53334235/how-to-properly-stop-a-foreground-service