### PR TITLE
Add support for deep links with fragmented activity

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.18.11
+
+* Add deep link support for FlutterFragmentActivity (@jan-milovanovic)
+
 ## 0.18.10
 
 * Add support for AGP 8 (@theskyblockman).

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.concurrent.Executors;
 
 import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.android.FlutterFragmentActivity;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
@@ -84,6 +85,15 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
                                 initialRoute += "?" + data.getQuery();
                             }
                         }
+                    }
+                }
+            } else if (context instanceof FlutterFragmentActivity) {
+                final FlutterFragmentActivity activity = (FlutterFragmentActivity)context;
+                Uri data = activity.getIntent().getData();
+                if (data != null) {
+                    initialRoute = data.getPath();
+                    if (data.getQuery() != null && !data.getQuery().isEmpty()) {
+                        initialRoute += "?" + data.getQuery();
                     }
                 }
             }

--- a/audio_service/example/lib/common.dart
+++ b/audio_service/example/lib/common.dart
@@ -110,7 +110,7 @@ class _SeekBarState extends State<SeekBar> {
                       .firstMatch("$_remaining")
                       ?.group(1) ??
                   '$_remaining',
-              style: Theme.of(context).textTheme.caption),
+              style: Theme.of(context).textTheme.bodySmall),
         ),
       ],
     );

--- a/audio_service/example/lib/example_playlist.dart
+++ b/audio_service/example/lib/example_playlist.dart
@@ -90,7 +90,7 @@ class MainScreen extends StatelessWidget {
                           ),
                         ),
                       Text(mediaItem.album ?? '',
-                          style: Theme.of(context).textTheme.headline6),
+                          style: Theme.of(context).textTheme.titleLarge),
                       Text(mediaItem.title),
                     ],
                   );
@@ -149,7 +149,7 @@ class MainScreen extends StatelessWidget {
                 Expanded(
                   child: Text(
                     "Playlist",
-                    style: Theme.of(context).textTheme.headline6,
+                    style: Theme.of(context).textTheme.titleLarge,
                     textAlign: TextAlign.center,
                   ),
                 ),

--- a/audio_service/pubspec.yaml
+++ b/audio_service/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_service
 description: Flutter plugin to play audio in the background while the screen is off.
-version: 0.18.10
+version: 0.18.11
 homepage: https://github.com/ryanheise/audio_service/tree/master/audio_service
 
 environment:


### PR DESCRIPTION
* Check for existing deep link paths for FlutterFragmentActivity and add it to inital route if it exists
* Additionally, bump version and fix text themes for examples as suggested by dart analyzer.

Fixes #1029

## Pre-launch Checklist

- [x] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [x] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [x] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [😶] I updated/added relevant documentation (doc comments with `///`).
- [x] I ran `dart analyze`.
- [x] I ran `dart format`.
- [x] I ran `flutter test` and all tests are passing.

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
