### PR TITLE
FEAT: implemented MPNowPlayingInfoPropertyIsLiveStream

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.18.13
+
+* Support for MPNowPlayingInfoPropertyIsLiveStream on IOS
+
 ## 0.18.12
 
 * Fix crash with Oppo/OnePlus devices running Android 13.

--- a/audio_service/darwin/Classes/AudioServicePlugin.m
+++ b/audio_service/darwin/Classes/AudioServicePlugin.m
@@ -291,6 +291,9 @@ static NSMutableDictionary *nowPlayingInfo = nil;
     if (@available(iOS 13.0, macOS 10.12.2, *)) {
         center.playbackState = playing ? MPNowPlayingPlaybackStatePlaying : MPNowPlayingPlaybackStatePaused;
     }
+    if (@available(iOS 10.0, macOS 10.12.2, *)) {
+        updated |= [self updateNowPlayingField:MPNowPlayingInfoPropertyIsLiveStream value:mediaItem[@"isLive"]];
+    }
     if (updated) {
         //NSLog(@"### updating nowPlayingInfo");
         center.nowPlayingInfo = nowPlayingInfo;
@@ -308,7 +311,6 @@ static NSMutableDictionary *nowPlayingInfo = nil;
     // * MPNowPlayingInfoPropertyCurrentPlaybackDate
     // * MPNowPlayingInfoPropertyExternalContentIdentifier
     // * MPNowPlayingInfoPropertyExternalUserProfileIdentifier
-    // * MPNowPlayingInfoPropertyIsLiveStream
     // * MPNowPlayingInfoPropertyPlaybackProgress
     // * MPNowPlayingInfoPropertyPlaybackQueueCount
     // * MPNowPlayingInfoPropertyPlaybackQueueIndex

--- a/audio_service/lib/audio_service.dart
+++ b/audio_service/lib/audio_service.dart
@@ -625,6 +625,9 @@ class MediaItem {
   /// The rating of the media item.
   final Rating? rating;
 
+  /// Whether this is a live stream.
+  final bool? isLive;
+
   /// A map of additional metadata for the media item.
   ///
   /// The values must be of type `int`, `String`, `bool` or `double`.
@@ -647,6 +650,7 @@ class MediaItem {
     this.displaySubtitle,
     this.displayDescription,
     this.rating,
+    this.isLive,
     this.extras,
   });
 
@@ -674,6 +678,7 @@ class MediaItem {
         displaySubtitle: displaySubtitle,
         displayDescription: displayDescription,
         rating: rating?._toMessage(),
+        isLive: isLive,
         extras: extras,
       );
 
@@ -697,6 +702,7 @@ abstract class MediaItemCopyWith {
     String? displaySubtitle,
     String? displayDescription,
     Rating? rating,
+    bool? isLive,
     Map<String, dynamic>? extras,
   });
 }
@@ -725,6 +731,7 @@ class _MediaItemCopyWith extends MediaItemCopyWith {
     Object? displaySubtitle = _fakeNull,
     Object? displayDescription = _fakeNull,
     Object? rating = _fakeNull,
+    Object? isLive = _fakeNull,
     Object? extras = _fakeNull,
   }) =>
       MediaItem(
@@ -747,6 +754,7 @@ class _MediaItemCopyWith extends MediaItemCopyWith {
             ? value.displayDescription
             : displayDescription as String?,
         rating: rating == _fakeNull ? value.rating : rating as Rating?,
+        isLive: isLive == _fakeNull ? value.isLive : isLive as bool?,
         extras: extras == _fakeNull
             ? value.extras
             : extras as Map<String, dynamic>?,
@@ -3582,6 +3590,7 @@ extension _MediaItemMessageExtension on MediaItemMessage {
         displaySubtitle: displaySubtitle,
         displayDescription: displayDescription,
         rating: rating?.toPlugin(),
+        isLive: isLive,
         extras: extras,
       );
 }

--- a/audio_service/pubspec.yaml
+++ b/audio_service/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_service
 description: Flutter plugin to play audio in the background while the screen is off.
-version: 0.18.12
+version: 0.18.13
 repository: https://github.com/ryanheise/audio_service/tree/minor/audio_service
 issue_tracker: https://github.com/ryanheise/audio_service/issues
 topics:

--- a/audio_service_platform_interface/CHANGELOG.md
+++ b/audio_service_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+* Support for MPNowPlayingInfoPropertyIsLiveStream on IOS
+
 ## 0.1.1
 
 * Add customAction to MediaControlMessage (@defsub)

--- a/audio_service_platform_interface/lib/audio_service_platform_interface.dart
+++ b/audio_service_platform_interface/lib/audio_service_platform_interface.dart
@@ -620,6 +620,9 @@ class MediaItemMessage {
   /// The rating of the MediaItemMessage.
   final RatingMessage? rating;
 
+  // Whether this is a livestream
+  final bool? isLive;
+
   /// A map of additional metadata for the media item.
   ///
   /// The values must be integers or strings.
@@ -642,6 +645,7 @@ class MediaItemMessage {
     this.displaySubtitle,
     this.displayDescription,
     this.rating,
+    this.isLive,
     this.extras,
   });
 
@@ -667,6 +671,7 @@ class MediaItemMessage {
             ? RatingMessage.fromMap(
                 _castMap(raw['rating'] as Map<dynamic, dynamic>)!)
             : null,
+        isLive: raw['isLive'] as bool?,
         extras: _castMap(raw['extras'] as Map<dynamic, dynamic>?),
       );
 
@@ -685,6 +690,7 @@ class MediaItemMessage {
         'displaySubtitle': displaySubtitle,
         'displayDescription': displayDescription,
         'rating': rating?.toMap(),
+        'isLive': isLive,
         'extras': extras,
       };
 }

--- a/audio_service_platform_interface/pubspec.yaml
+++ b/audio_service_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the audio_service plugin. Different
 homepage: https://github.com/ryanheise/audio_service/tree/master/audio_service_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 0.1.1
+version: 0.1.2
 
 dependencies:
   flutter:


### PR DESCRIPTION
Adding MPNowPlayingInfoPropertyIsLiveStream, so we can livestream audio with just_audio.

## Pre-launch Checklist

- [x] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [x] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [x] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I ran `dart analyze`.
- [x] I ran `dart format`.
- [x] I ran `flutter test` and all tests are passing.

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
