### PR TITLE
Fix/set android playback info

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.18.13
+
+* Fix setAndroidPlaybackInfo call blocking.
+
 ## 0.18.12
 
 * Fix crash with Oppo/OnePlus devices running Android 13.

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
@@ -916,6 +916,7 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
                 final Integer maxVolume = (Integer)playbackInfo.get("maxVolume");
                 final Integer volume = (Integer)playbackInfo.get("volume");
                 AudioService.instance.setPlaybackInfo(playbackType, volumeControlType, maxVolume, volume);
+                result.success(null);
                 break;
             }
             case "notifyChildrenChanged": {

--- a/audio_service/pubspec.yaml
+++ b/audio_service/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_service
 description: Flutter plugin to play audio in the background while the screen is off.
-version: 0.18.12
+version: 0.18.13
 repository: https://github.com/ryanheise/audio_service/tree/minor/audio_service
 issue_tracker: https://github.com/ryanheise/audio_service/issues
 topics:


### PR DESCRIPTION
The method handler for setAndroidPlaybackInfo missed setting the result, which caused the call to block on dart level.

## Pre-launch Checklist

- [x] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [x] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [x] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I ran `dart analyze`.
- [x] I ran `dart format`.
- [x] I ran `flutter test` and all tests are passing.

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
