### PR TITLE
Fixing issue 994 ForegroundServiceStartNotAllowedException

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.18.14
+
+* Fix ForegroundServiceStartNotAllowedException when androidDisableForeground is set to true.
+
 ## 0.18.13
 
 * Fix setAndroidPlaybackInfo call blocking (@julianscheel).

--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.18.14
 
-* Fix ForegroundServiceStartNotAllowedException when androidDisableForeground is set to true.
+* Fix ForegroundServiceStartNotAllowedException when androidDisableForeground is set to true (@JoseBarreto1).
 
 ## 0.18.13
 

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -714,7 +714,9 @@ public class AudioService extends MediaBrowserServiceCompat {
     }
 
     private void enterPlayingState() {
-        ContextCompat.startForegroundService(this, new Intent(AudioService.this, AudioService.class));
+        if (!config.androidDisableForeground) {
+            ContextCompat.startForegroundService(this, new Intent(AudioService.this, AudioService.class));
+        }
         if (!mediaSession.isActive())
             mediaSession.setActive(true);
 
@@ -730,12 +732,16 @@ public class AudioService extends MediaBrowserServiceCompat {
     }
 
     private void exitForegroundState() {
-        legacyStopForeground(false);
-        releaseWakeLock();
+        if (!config.androidDisableForeground) {
+            legacyStopForeground(false);
+            releaseWakeLock();
+        }
     }
 
     private void internalStartForeground() {
-        startForeground(NOTIFICATION_ID, buildNotification());
+        if (!config.androidDisableForeground) {
+            startForeground(NOTIFICATION_ID, buildNotification());
+        }
         notificationCreated = true;
     }
 

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServiceConfig.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServiceConfig.java
@@ -19,6 +19,7 @@ public class AudioServiceConfig {
     private static final String KEY_ANDROID_NOTIFICATION_CLICK_STARTS_ACTIVITY = "androidNotificationClickStartsActivity";
     private static final String KEY_ANDROID_NOTIFICATION_ONGOING = "androidNotificationOngoing";
     private static final String KEY_ANDROID_STOP_FOREGROUND_ON_PAUSE = "androidStopForegroundOnPause";
+    private static final String KEY_ANDROID_DISABLE_FOREGROUND = "androidDisableForeground";
     private static final String KEY_ART_DOWNSCALE_WIDTH = "artDownscaleWidth";
     private static final String KEY_ART_DOWNSCALE_HEIGHT = "artDownscaleHeight";
     private static final String KEY_ACTIVITY_CLASS_NAME = "activityClassName";
@@ -35,6 +36,7 @@ public class AudioServiceConfig {
     public boolean androidNotificationClickStartsActivity;
     public boolean androidNotificationOngoing;
     public boolean androidStopForegroundOnPause;
+    public boolean androidDisableForeground;
     public int artDownscaleWidth;
     public int artDownscaleHeight;
     public String activityClassName;
@@ -52,6 +54,7 @@ public class AudioServiceConfig {
         androidNotificationClickStartsActivity = preferences.getBoolean(KEY_ANDROID_NOTIFICATION_CLICK_STARTS_ACTIVITY, true);
         androidNotificationOngoing = preferences.getBoolean(KEY_ANDROID_NOTIFICATION_ONGOING, false);
         androidStopForegroundOnPause = preferences.getBoolean(KEY_ANDROID_STOP_FOREGROUND_ON_PAUSE, true);
+        androidDisableForeground = preferences.getBoolean(KEY_ANDROID_DISABLE_FOREGROUND, false);
         artDownscaleWidth = preferences.getInt(KEY_ART_DOWNSCALE_WIDTH, -1);
         artDownscaleHeight = preferences.getInt(KEY_ART_DOWNSCALE_HEIGHT, -1);
         activityClassName = preferences.getString(KEY_ACTIVITY_CLASS_NAME, null);
@@ -111,6 +114,7 @@ public class AudioServiceConfig {
             .putBoolean(KEY_ANDROID_NOTIFICATION_CLICK_STARTS_ACTIVITY, androidNotificationClickStartsActivity)
             .putBoolean(KEY_ANDROID_NOTIFICATION_ONGOING, androidNotificationOngoing)
             .putBoolean(KEY_ANDROID_STOP_FOREGROUND_ON_PAUSE, androidStopForegroundOnPause)
+            .putBoolean(KEY_ANDROID_DISABLE_FOREGROUND, androidDisableForeground)
             .putInt(KEY_ART_DOWNSCALE_WIDTH, artDownscaleWidth)
             .putInt(KEY_ART_DOWNSCALE_HEIGHT, artDownscaleHeight)
             .putString(KEY_ACTIVITY_CLASS_NAME, activityClassName)

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
@@ -457,6 +457,7 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
                     config.androidNotificationIcon = (String)configMap.get("androidNotificationIcon");
                     config.androidShowNotificationBadge = (Boolean)configMap.get("androidShowNotificationBadge");
                     config.androidStopForegroundOnPause = (Boolean)configMap.get("androidStopForegroundOnPause");
+                    config.androidDisableForeground = (Boolean)configMap.get("androidDisableForeground");
                     config.artDownscaleWidth = configMap.get("artDownscaleWidth") != null ? (Integer)configMap.get("artDownscaleWidth") : -1;
                     config.artDownscaleHeight = configMap.get("artDownscaleHeight") != null ? (Integer)configMap.get("artDownscaleHeight") : -1;
                     config.setBrowsableRootExtras((Map<?,?>)configMap.get("androidBrowsableRootExtras"));

--- a/audio_service/lib/audio_service.dart
+++ b/audio_service/lib/audio_service.dart
@@ -3446,6 +3446,9 @@ class AudioServiceConfig {
   /// able to kill your service at any time to reclaim resources.
   final bool androidStopForegroundOnPause;
 
+  /// If you set this to true Disable Foreground
+  final bool androidDisableForeground;
+
   /// If not null, causes the artwork specified by [MediaItem.artUri] to be
   /// downscaled to this maximum pixel width. If the resolution of your artwork
   /// is particularly high, this can help to conserve memory. If specified,
@@ -3489,6 +3492,7 @@ class AudioServiceConfig {
     this.androidNotificationClickStartsActivity = true,
     this.androidNotificationOngoing = false,
     this.androidStopForegroundOnPause = true,
+    this.androidDisableForeground = false,
     this.artDownscaleWidth,
     this.artDownscaleHeight,
     this.fastForwardInterval = const Duration(seconds: 10),
@@ -3514,6 +3518,7 @@ class AudioServiceConfig {
             androidNotificationClickStartsActivity,
         androidNotificationOngoing: androidNotificationOngoing,
         androidStopForegroundOnPause: androidStopForegroundOnPause,
+        androidDisableForeground: androidDisableForeground,
         artDownscaleWidth: artDownscaleWidth,
         artDownscaleHeight: artDownscaleHeight,
         fastForwardInterval: fastForwardInterval,

--- a/audio_service/pubspec.yaml
+++ b/audio_service/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_service
 description: Flutter plugin to play audio in the background while the screen is off.
-version: 0.18.13
+version: 0.18.14
 repository: https://github.com/ryanheise/audio_service/tree/minor/audio_service
 issue_tracker: https://github.com/ryanheise/audio_service/issues
 topics:

--- a/audio_service_platform_interface/CHANGELOG.md
+++ b/audio_service_platform_interface/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.2
+* Add interface androidDisableForeground
+
 ## 0.1.1
 
 * Add customAction to MediaControlMessage (@defsub)

--- a/audio_service_platform_interface/lib/audio_service_platform_interface.dart
+++ b/audio_service_platform_interface/lib/audio_service_platform_interface.dart
@@ -1350,6 +1350,9 @@ class AudioServiceConfigMessage {
   /// able to kill your service at any time to reclaim resources.
   final bool androidStopForegroundOnPause;
 
+  /// If you set this to true Disable Foreground
+  final bool androidDisableForeground;
+
   /// If not null, causes the artwork specified by [MediaItemMessage.artUri] to be
   /// downscaled to this maximum pixel width. If the resolution of your artwork
   /// is particularly high, this can help to conserve memory. If specified,
@@ -1395,6 +1398,7 @@ class AudioServiceConfigMessage {
     this.androidNotificationClickStartsActivity = true,
     this.androidNotificationOngoing = false,
     this.androidStopForegroundOnPause = true,
+    this.androidDisableForeground = false,
     this.artDownscaleWidth,
     this.artDownscaleHeight,
     this.fastForwardInterval = const Duration(seconds: 10),
@@ -1422,6 +1426,7 @@ class AudioServiceConfigMessage {
             androidNotificationClickStartsActivity,
         'androidNotificationOngoing': androidNotificationOngoing,
         'androidStopForegroundOnPause': androidStopForegroundOnPause,
+        'androidDisableForeground': androidDisableForeground,
         'artDownscaleWidth': artDownscaleWidth,
         'artDownscaleHeight': artDownscaleHeight,
         'fastForwardInterval': fastForwardInterval.inMilliseconds,

--- a/audio_service_platform_interface/pubspec.yaml
+++ b/audio_service_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the audio_service plugin. Different
 homepage: https://github.com/ryanheise/audio_service/tree/master/audio_service_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 0.1.1
+version: 0.1.2
 
 dependencies:
   flutter:


### PR DESCRIPTION
Avoiding ForegroundServiceStartNotAllowedException when android Disable Foreground is set to true.

Open issue that my PR is fixing: https://github.com/ryanheise/audio_service/issues/994

## Pre-launch Checklist

- [X] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [X] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [X] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I ran `dart analyze`.
- [X] I ran `dart format`.
- [X] I ran `flutter test` and all tests are passing.

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
