### PR TITLE
Fix error handling in onLoadChildren, onLoadItem and onSearch

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.18.16
+* Fix error handling in onLoadChildren, onLoadItem and onSearch (@dsst95)
+
 ## 0.18.15
 
 * Add deep link support for FlutterFragmentActivity (@jan-milovanovic).

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
@@ -1039,7 +1039,7 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
                     0,
                     0,
                     false,
-                    0L);
+                    null);
         }
     }
 

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
@@ -551,12 +551,13 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
                 audioHandlerInterface.invokeMethod("getChildren", args, new MethodChannel.Result() {
                     @Override
                     public void error(String errorCode, String errorMessage, Object errorDetails) {
-                        result.sendError(new Bundle());
+                        setErrorState(errorCode, errorMessage);
+                        result.sendResult(null);
                     }
 
                     @Override
                     public void notImplemented() {
-                        result.sendError(new Bundle());
+                        result.sendResult(null);
                     }
 
                     @Override
@@ -583,12 +584,13 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
                 audioHandlerInterface.invokeMethod("getMediaItem", args, new MethodChannel.Result() {
                     @Override
                     public void error(String errorCode, String errorMessage, Object errorDetails) {
-                        result.sendError(new Bundle());
+                        setErrorState(errorCode, errorMessage);
+                        result.sendResult(null);
                     }
 
                     @Override
                     public void notImplemented() {
-                        result.sendError(new Bundle());
+                        result.sendResult(null);
                     }
 
                     @Override
@@ -616,12 +618,13 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
                 audioHandlerInterface.invokeMethod("search", args, new MethodChannel.Result() {
                     @Override
                     public void error(String errorCode, String errorMessage, Object errorDetails) {
-                        result.sendError(new Bundle());
+                        setErrorState(errorCode, errorMessage);
+                        result.sendResult(null);
                     }
 
                     @Override
                     public void notImplemented() {
-                        result.sendError(new Bundle());
+                        result.sendResult(null);
                     }
 
                     @Override
@@ -1018,6 +1021,25 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
         private void destroy() {
             if (silenceAudioTrack != null)
                 silenceAudioTrack.release();
+        }
+
+        private void setErrorState(String errorCode, String errorMessage)  {
+            AudioService.instance.setState(
+                    new ArrayList<MediaControl>(),
+                    0,
+                    null,
+                    AudioProcessingState.error,
+                    false,
+                    0,
+                    0,
+                    0,
+                    0,
+                    Integer.parseInt(errorCode),
+                    errorMessage,
+                    0,
+                    0,
+                    false,
+                    0L);
         }
     }
 

--- a/audio_service/pubspec.yaml
+++ b/audio_service/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_service
 description: Flutter plugin to play audio in the background while the screen is off.
-version: 0.18.15
+version: 0.18.16
 repository: https://github.com/ryanheise/audio_service/tree/minor/audio_service
 issue_tracker: https://github.com/ryanheise/audio_service/issues
 topics:


### PR DESCRIPTION
Changed error handling for onLoadChildren, onLoadItem and onSearch, since the existing implementation leads to an error according to an deprecated method call. According to the new android documentation for an error a null result must be send and the error state must be set.

* Fixes #1081

## Pre-launch Checklist

- [x] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [x] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [x] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I ran `dart analyze`.
- [x] I ran `dart format`.
- [x] I ran `flutter test` and all tests are passing.

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
