### PR TITLE
Fix setPlaybackState entitlement issue on iOS.

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.18.18
+
+* Fix setPlaybackState entitlement issue on iOS.
+
 ## 0.18.17
 
 * Add support for SwiftPM.

--- a/audio_service/darwin/audio_service/Sources/audio_service/AudioServicePlugin.m
+++ b/audio_service/darwin/audio_service/Sources/audio_service/AudioServicePlugin.m
@@ -289,9 +289,11 @@ static NSMutableDictionary *nowPlayingInfo = nil;
     updated |= [self updateNowPlayingField:MPNowPlayingInfoPropertyDefaultPlaybackRate value:(playing ? speed : [NSNumber numberWithDouble: 0.0])];
     updated |= [self updateNowPlayingField:MPNowPlayingInfoPropertyElapsedPlaybackTime value:[NSNumber numberWithDouble:([position doubleValue] / 1000)]];
     MPNowPlayingInfoCenter *center = [MPNowPlayingInfoCenter defaultCenter];
+#if TARGET_OS_OSX
     if (@available(iOS 13.0, macOS 10.12.2, *)) {
         center.playbackState = playing ? MPNowPlayingPlaybackStatePlaying : MPNowPlayingPlaybackStatePaused;
     }
+#endif
     if (@available(iOS 10.0, macOS 10.12.2, *)) {
         updated |= [self updateNowPlayingField:MPNowPlayingInfoPropertyIsLiveStream value:mediaItem[@"isLive"]];
     }

--- a/audio_service/pubspec.yaml
+++ b/audio_service/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_service
 description: Flutter plugin to play audio in the background while the screen is off.
-version: 0.18.17
+version: 0.18.18
 repository: https://github.com/ryanheise/audio_service/tree/minor/audio_service
 issue_tracker: https://github.com/ryanheise/audio_service/issues
 topics:


### PR DESCRIPTION
Fixes the entitlement issue with setPlaybackState on iOS, described in #900 .

## Pre-launch Checklist

- [X] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [X] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [X] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I ran `dart analyze`.
- [X] I ran `dart format`.
- [X] I ran `flutter test` and all tests are passing.

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
