### PR TITLE
fix: buildNotification crash app on older Android versions

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.18.19
+
+* Fix buildNotification on older Android devices
+
 ## 0.18.18
 
 * Fix setPlaybackState entitlement issue on iOS.

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -611,10 +611,11 @@ public class AudioService extends MediaBrowserServiceCompat {
     }
 
     private Notification buildNotification() {
-        int[] compactActionIndices = this.compactActionIndices;
-        if (compactActionIndices == null) {
-            compactActionIndices = new int[Math.min(MAX_COMPACT_ACTIONS, nativeActions.size())];
-            for (int i = 0; i < compactActionIndices.length; i++) compactActionIndices[i] = i;
+        int actionCount = nativeActions.size();
+        int maxCompact = Math.min(MAX_COMPACT_ACTIONS, actionCount);
+        int[] compactIndices = new int[maxCompact];
+        for (int i = 0; i < maxCompact; i++) {
+            compactIndices[i] = i;
         }
         NotificationCompat.Builder builder = getNotificationBuilder();
         if (mediaMetadata != null) {
@@ -640,8 +641,9 @@ public class AudioService extends MediaBrowserServiceCompat {
         }
         final MediaStyle style = new MediaStyle()
             .setMediaSession(mediaSession.getSessionToken());
-        if (Build.VERSION.SDK_INT < 33) {
-            style.setShowActionsInCompactView(compactActionIndices);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+                && Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU && maxCompact > 0) {
+            style.setShowActionsInCompactView(compactIndices);
         }
         if (config.androidNotificationOngoing) {
             style.setShowCancelButton(true);

--- a/audio_service/pubspec.yaml
+++ b/audio_service/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_service
 description: Flutter plugin to play audio in the background while the screen is off.
-version: 0.18.18
+version: 0.18.19
 repository: https://github.com/ryanheise/audio_service/tree/minor/audio_service
 issue_tracker: https://github.com/ryanheise/audio_service/issues
 topics:
@@ -34,11 +34,11 @@ dependencies:
   audio_service_platform_interface: ^0.1.3
   audio_service_web: ^0.1.4
 
-  audio_session: '>=0.1.25 <0.3.0'
-  rxdart: '>=0.26.0 <0.29.0'
+  audio_session: ">=0.1.25 <0.3.0"
+  rxdart: ">=0.26.0 <0.29.0"
   flutter_cache_manager: ^3.3.1
   clock: ^1.1.0
-  js: '>=0.6.3 <0.8.0'
+  js: ">=0.6.3 <0.8.0"
   flutter:
     sdk: flutter
   flutter_web_plugins:


### PR DESCRIPTION
Probably due to older versions of Java on devices running Android version 7, when running Play, the notification wouldn't display and the app would crash.

After investigating the code, I found the problem was in the way the compactActionIndices were loaded.

I have tested it on Android devices with version 7 Meizu M5 Note and M8C, Realme with Andriod 13 and Samsung with Android 14. Now it works correctly

## Pre-launch Checklist

- [x] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [x] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [x] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I ran `dart analyze`.
- [x] I ran `dart format`.
- [x] I ran `flutter test` and all tests are passing.

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
