### PR TITLE
Fix Android plugin: Handle intent and provide result if the intent is consumed

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.18.19
+
+* Fix onNewIntentListener always returns true (@relaxedSoul)
+  It prevents other plugins to handle new intents from the OS while the app is running. 
+
 ## 0.18.18
 
 * Fix setPlaybackState entitlement issue on iOS.

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
@@ -327,7 +327,7 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
             // We do this to avoid using the old intent.
             activity.setIntent(new Intent(Intent.ACTION_MAIN));
         }
-        sendNotificationClicked();
+        handleIntent(activity.getIntent());
     }
 
     @Override
@@ -393,17 +393,17 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
     private void registerOnNewIntentListener() {
         activityPluginBinding.addOnNewIntentListener(newIntentListener = (intent) -> {
             clientInterface.activity.setIntent(intent);
-            sendNotificationClicked();
-            return true;
+            return handleIntent(intent);
         });
     }
 
-    private void sendNotificationClicked() {
-        Activity activity = clientInterface.activity;
-        if (audioHandlerInterface != null && activity.getIntent().getAction() != null) {
-            boolean clicked = activity.getIntent().getAction().equals(AudioService.NOTIFICATION_CLICK_ACTION);
-            audioHandlerInterface.invokeMethod("onNotificationClicked", mapOf("clicked", clicked));
+    private boolean handleIntent(Intent intent) {
+        if (audioHandlerInterface != null && intent.getAction() != null) {
+            boolean handled = intent.getAction().equals(AudioService.NOTIFICATION_CLICK_ACTION);
+            audioHandlerInterface.invokeMethod("onNotificationClicked", mapOf("clicked", handled));
+            return handled;
         }
+        return false;
     }
 
     private static class ClientInterface implements MethodCallHandler {

--- a/audio_service/pubspec.yaml
+++ b/audio_service/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_service
 description: Flutter plugin to play audio in the background while the screen is off.
-version: 0.18.18
+version: 0.18.19
 repository: https://github.com/ryanheise/audio_service/tree/minor/audio_service
 issue_tracker: https://github.com/ryanheise/audio_service/issues
 topics:


### PR DESCRIPTION
### Context
When the Android OS opens the application with deeplink/applink (to simplify - `applink`), they are provided to the app inside the `Intent`. 
The app can already be running and the `Activity` is in the foreground, registered to handle the Intent with a specific intent filter. The `applink` will be delivered by the method `onNewIntent`.
Flutter provides a way to handle such links - the `flutterPlugin` or `flutterEngine` should implement the interface `onNewIntentListener`.

### The bug
The audio service implements this interface, but if the `applink` is supposed to be delivered to another plugin, its listener will not be called, because the audio service listener always returns true from the function `onNewIntent`.
If another listener waits for intent, it will never receive it, even if the `applink` was not for audio service, but for another purpose. 

### Where it happens
AudioServicePlugin.java -> onAttachedToActivity method.
The method registerOnNewIntentListener() is called, and from now on, the intents will be handled by `newIntentListener`.
The implementation of the interface, its single method, always returns `true`.
The value returned here is used by Flutter (OS, eventually) to call or not call the next listener in the... I don't know if a list or a stack. I believe in the list (FIFO).
The result `true` signs that the intent was consumed, and no other listeners should be called. 

### Fix
As far as I see, there is a method inside that makes the check, and if it fails, the intent is not handled at all. I believe this check also should deliver the result "is handled" back to the caller, and the result should be returned. 

### Issues or tickets, or PRs in repo
I couldn't find anything related to this bug, but there is a chance the changes will solve some other bugs: the onNewIntent handling can have a large impact on various plugins, which depend on app link handling or deeplinks.

## Pre-launch Checklist

- [x] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [x] **My change is not breaking and lands in `minor` branch** OR my change is breaking and lands in `major` branch.
- [x] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I ran `dart analyze`.
- [x] I ran `dart format`.
- [x] I ran `flutter test` and all tests are passing.

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
