### PR TITLE
Fix android initial route parsing

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.18.19
+
+* Add url fragment support for Android deep links
+
 ## 0.18.18
 
 * Fix setPlaybackState entitlement issue on iOS.

--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
@@ -85,6 +85,9 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
                             if (data.getQuery() != null && !data.getQuery().isEmpty()) {
                                 initialRoute += "?" + data.getQuery();
                             }
+                            if (data.getFragment() != null && !data.getFragment().isEmpty()) {
+                                initialRoute += "#" + data.getFragment();
+                            }
                         }
                     }
                 }
@@ -98,6 +101,9 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
                             initialRoute = data.getPath();
                             if (data.getQuery() != null && !data.getQuery().isEmpty()) {
                                 initialRoute += "?" + data.getQuery();
+                            }
+                            if (data.getFragment() != null && !data.getFragment().isEmpty()) {
+                                initialRoute += "#" + data.getFragment();
                             }
                         }
                     }


### PR DESCRIPTION
This PR adds support for preserving URL fragments (the part after `#`) in deep links when initializing the route in `AudioServiceFragmentActivity` and `AudioServiceActivity`. 

The change involves adding this line:
```java
if (data.getFragment() != null && !data.getFragment().isEmpty()) {
    initialRoute += "#" + data.getFragment();
}
```

The modification was made to properly handle deep links containing fragments (e.g., `https://example.www/web-player#/tv/groups/allChannels/channel/2/)`) when the app is launched from a cold state. Previously, the fragment portion of the URL was being dropped during initial route processing, which could break navigation to specific internal locations.

The change maintains consistency with how query parameters (the part after `?`) are already handled, ensuring all parts of a deep link URL (path, query parameters, and fragment) are properly preserved in the initial route.

This fixes an issue where the app would lose the `internalPath` portion of deep links when launched from a cold state (when the app wasn't already running).


## Pre-launch Checklist

- [x] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [x] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [x] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I ran `dart analyze`.
- [x] I ran `dart format`.
- [x] I ran `flutter test` and all tests are passing.

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
