### PR TITLE
Merge Fix playing state not reported correctly to iOS

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.18.19
+
+* Fix AudioServicePlugin not reporting playing state to iOS versions >= 13.0 (@marckornberger)
+
 ## 0.18.18
 
 * Fix setPlaybackState entitlement issue on iOS.

--- a/audio_service/darwin/audio_service/Sources/audio_service/AudioServicePlugin.m
+++ b/audio_service/darwin/audio_service/Sources/audio_service/AudioServicePlugin.m
@@ -290,10 +290,13 @@ static NSMutableDictionary *nowPlayingInfo = nil;
     updated |= [self updateNowPlayingField:MPNowPlayingInfoPropertyElapsedPlaybackTime value:[NSNumber numberWithDouble:([position doubleValue] / 1000)]];
     MPNowPlayingInfoCenter *center = [MPNowPlayingInfoCenter defaultCenter];
 #if TARGET_OS_OSX
-    if (@available(iOS 13.0, macOS 10.12.2, *)) {
+    if (@available(macOS 10.12.2, *)) {
         center.playbackState = playing ? MPNowPlayingPlaybackStatePlaying : MPNowPlayingPlaybackStatePaused;
     }
 #endif
+    if (@available(iOS 13.0, *)) {
+        center.playbackState = playing ? MPNowPlayingPlaybackStatePlaying : MPNowPlayingPlaybackStatePaused;
+    }
     if (@available(iOS 10.0, macOS 10.12.2, *)) {
         updated |= [self updateNowPlayingField:MPNowPlayingInfoPropertyIsLiveStream value:mediaItem[@"isLive"]];
     }


### PR DESCRIPTION
This PR fixes the fact that a `#if TARGET_OS_OSX` is excluding code from the build that would correctly report the playing state of the app to iOS versions >= 13.0 therefore breaking OS integrations

[Issue fixed by this PR](https://github.com/ryanheise/audio_service/issues/1139)

## Pre-launch Checklist

- [x] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [x] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [x] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I ran `dart analyze`.
- [x] I ran `dart format`.
- [x] I ran `flutter test` and all tests are passing.

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
