### PR TITLE
Updated deprecated initWithImage.

### DIFF
--- a/audio_service/darwin/audio_service/Sources/audio_service/AudioServicePlugin.m
+++ b/audio_service/darwin/audio_service/Sources/audio_service/AudioServicePlugin.m
@@ -210,9 +210,11 @@ static NSMutableDictionary *nowPlayingInfo = nil;
 #endif
                 if (artImage != nil) {
 #if TARGET_OS_IPHONE
-                    artwork = [[MPMediaItemArtwork alloc] initWithImage: artImage];
+                    artwork = [[MPMediaItemArtwork alloc] initWithBoundsSize:artImage.size requestHandler:^UIImage * _Nonnull(CGSize size) {
+                        return artImage;
+                    }];
 #else
-                    artwork = [[MPMediaItemArtwork alloc] initWithBoundsSize:artImage.size requestHandler:^NSImage* _Nonnull(CGSize aSize) {
+                    artwork = [[MPMediaItemArtwork alloc] initWithBoundsSize:artImage.size requestHandler:^NSImage * _Nonnull(CGSize size) {
                         return artImage;
                     }];
 #endif

--- a/audio_service/pubspec.yaml
+++ b/audio_service/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_service
 description: Flutter plugin to play audio in the background while the screen is off.
-version: 0.18.18
+version: 0.18.19
 repository: https://github.com/ryanheise/audio_service/tree/minor/audio_service
 issue_tracker: https://github.com/ryanheise/audio_service/issues
 topics:

--- a/audio_service_platform_interface/CHANGELOG.md
+++ b/audio_service_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.18.19
+
+* Fix deprecated withInitImage
+
 ## 0.1.3
 
 * Fix deprecated Color.value.


### PR DESCRIPTION
Replaced initWithImage with initWithBoundsSize, as initWithImage is deprecated

*If there's an open issue your PR is fixing, please list it here.*

## Pre-launch Checklist

- [ x] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [ x] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [ x] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [ x] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [ x] I updated/added relevant documentation (doc comments with `///`).
- [ x] I ran `dart analyze`.
- [ x] I ran `dart format`.
- [ x] I ran `flutter test` and all tests are passing.

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
