### PR TITLE
Fix #1138: mention audio_service_win for Windows support

### DIFF
--- a/audio_service/README.md
+++ b/audio_service/README.md
@@ -1,6 +1,6 @@
 # audio_service
 
-This plugin wraps around your existing audio code to allow it to run in the background and interact with the media notification, the lock screen, headset buttons, wearables and Android Auto. It supports Android, iOS, web and Linux (via [audio_service_mpris](https://pub.dev/packages/audio_service_mpris)). It is suitable for:
+This plugin wraps around your existing audio code to allow it to run in the background and interact with the media notification, the lock screen, headset buttons, wearables and Android Auto. It supports Android, iOS, web, Linux (via [audio_service_mpris](https://pub.dev/packages/audio_service_mpris)) and Windows (via [audio_service_win](https://pub.dev/packages/audio_service_win)). It is suitable for:
 
 * Music players
 * Text-to-speech readers


### PR DESCRIPTION
Closes #1138.

The README lists Linux support via [`audio_service_mpris`](https://pub.dev/packages/audio_service_mpris) but doesn't mention [`audio_service_win`](https://pub.dev/packages/audio_service_win), which is a federated implementation against `audio_service_platform_interface` exposing SMTC on Windows. Adds Windows alongside Linux in the platform list in the same parenthetical style.

Docs-only change. No code touched.