### PR TITLE
feat: favorite integration audio service

### DIFF
--- a/audio_service/CHANGELOG.md
+++ b/audio_service/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.18.19
+
+* [iOS] Implement `MediaAction.setRating` for all rating styles: `heart` (like/unlike via `MPFeedbackCommand`), `thumbUpDown` (like + dislike via `MPFeedbackCommand`), `range3stars`/`range4stars`/`range5stars` and `percentage` (via `MPRatingCommand`). Rating commands are dynamically enabled/disabled and kept in sync whenever the media item changes (@EArminjon)
+* [iOS] Support `heart` and `thumbUpDown` rating types in `CPNowPlayingTemplate` on CarPlay (iOS 14+). When the corresponding command is active, a `CPNowPlayingImageButton` using SF Symbols (`star`/`star.fill` or `hand.thumbsdown`/`hand.thumbsdown.fill`) is added to the CarPlay NowPlaying screen. Tapping the button invokes the Flutter `setRating` callback and the button state updates immediately. `CarPlay.framework` is linked as a system framework (iOS only) and requires no special entitlement — calls are silently ignored when no CarPlay screen is connected (@EArminjon)
+
 ## 0.18.18
 
 * Fix setPlaybackState entitlement issue on iOS.

--- a/audio_service/darwin/audio_service/Package.swift
+++ b/audio_service/darwin/audio_service/Package.swift
@@ -19,6 +19,14 @@ let package = Package(
             dependencies: [],
             cSettings: [
                 .headerSearchPath("include/audio_service")
+            ],
+            linkerSettings: [
+                // CarPlay is used on iOS 14+ to update CPNowPlayingTemplate buttons
+                // when a rating command (like/dislike) is active.
+                // The framework is a system framework and does NOT require the CarPlay
+                // entitlement — calling updateNowPlayingButtons is a no-op when no
+                // CarPlay screen is connected.
+                .linkedFramework("CarPlay", .when(platforms: [.iOS]))
             ]
         )
     ]

--- a/audio_service/darwin/audio_service/Sources/audio_service/AudioServicePlugin.m
+++ b/audio_service/darwin/audio_service/Sources/audio_service/AudioServicePlugin.m
@@ -1,6 +1,9 @@
 #import "./include/audio_service/AudioServicePlugin.h"
 #import <AVFoundation/AVFoundation.h>
 #import <MediaPlayer/MediaPlayer.h>
+#if TARGET_OS_IPHONE
+#import <CarPlay/CarPlay.h>
+#endif
 
 // If you'd like to help, please see the TODO comments below, then open a
 // GitHub issue to announce your intention to work on a particular feature, and
@@ -133,6 +136,58 @@ static NSMutableDictionary *nowPlayingInfo = nil;
     [commandCenter.likeCommand setEnabled:NO];
     [commandCenter.dislikeCommand setEnabled:NO];
     [commandCenter.bookmarkCommand setEnabled:NO];
+}
+
+// Static helpers called from CarPlay CPNowPlayingImageButton handlers.
+// They reference only static variables so no instance capture is needed.
+
+// Forward declaration — defined later after the @implementation block.
+#if TARGET_OS_IPHONE
+static void refreshCarPlayNowPlayingButtons(void) API_AVAILABLE(ios(14.0));
+#endif
+
+static void handleCarPlayLikeButtonTap() {
+    if (!commandCenter || !handlerChannel) return;
+    NSDictionary *ratingDict = nil;
+    if (mediaItem != nil && mediaItem[@"rating"] != nil && mediaItem[@"rating"] != (id)[NSNull null]) {
+        ratingDict = mediaItem[@"rating"];
+    }
+    int ratingType = ratingDict ? [ratingDict[@"type"] intValue] : 1;
+    NSDictionary *rating;
+    if (ratingType == 2) {
+        commandCenter.likeCommand.active = YES;
+        commandCenter.dislikeCommand.active = NO;
+        rating = @{@"type": @(2), @"value": @(YES)};
+    } else {
+        rating = @{@"type": @(1), @"value": @(commandCenter.likeCommand.active)};
+    }
+    [handlerChannel invokeMethod:@"setRating" arguments:@{
+        @"rating": rating,
+        @"extras": [NSNull null]
+    }];
+    // Immediately rebuild buttons so the icon reflects the toggled state.
+#if TARGET_OS_IPHONE
+    if (@available(iOS 14.0, *)) {
+        refreshCarPlayNowPlayingButtons();
+    }
+#endif
+}
+
+static void handleCarPlayDislikeButtonTap() {
+    if (!commandCenter || !handlerChannel) return;
+    // thumbUpDown: dislike = thumbs down; update active states for instant feedback
+    commandCenter.likeCommand.active = NO;
+    commandCenter.dislikeCommand.active = YES;
+    NSDictionary *rating = @{@"type": @(2), @"value": @(NO)};
+    [handlerChannel invokeMethod:@"setRating" arguments:@{
+        @"rating": rating,
+        @"extras": [NSNull null]
+    }];
+#if TARGET_OS_IPHONE
+    if (@available(iOS 14.0, *)) {
+        refreshCarPlayNowPlayingButtons();
+    }
+#endif
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
@@ -393,6 +448,12 @@ static NSMutableDictionary *nowPlayingInfo = nil;
                     break;
             }
         }
+        // Update CarPlay NowPlaying template buttons to reflect the new rating state.
+#if TARGET_OS_IPHONE
+        if (@available(iOS 14.0, *)) {
+            [self updateCarPlayNowPlayingButtons];
+        }
+#endif
         return;
     }
 
@@ -682,5 +743,40 @@ static NSMutableDictionary *nowPlayingInfo = nil;
 - (void) dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
+
+#if TARGET_OS_IPHONE
+static void refreshCarPlayNowPlayingButtons(void) API_AVAILABLE(ios(14.0)) {
+    if (!commandCenter) return;
+    NSMutableArray *buttons = [NSMutableArray new];
+
+    if (commandCenter.likeCommand.isEnabled) {
+        BOOL isActive = commandCenter.likeCommand.active;
+        UIImage *image = [UIImage systemImageNamed:(isActive ? @"star.fill" : @"star")];
+        if (image) {
+            CPNowPlayingImageButton *btn = [[CPNowPlayingImageButton alloc]
+                initWithImage:image
+                handler:^(CPNowPlayingButton *b) { handleCarPlayLikeButtonTap(); }];
+            [buttons addObject:btn];
+        }
+    }
+
+    if (commandCenter.dislikeCommand.isEnabled) {
+        BOOL isActive = commandCenter.dislikeCommand.active;
+        UIImage *image = [UIImage systemImageNamed:(isActive ? @"hand.thumbsdown.fill" : @"hand.thumbsdown")];
+        if (image) {
+            CPNowPlayingImageButton *btn = [[CPNowPlayingImageButton alloc]
+                initWithImage:image
+                handler:^(CPNowPlayingButton *b) { handleCarPlayDislikeButtonTap(); }];
+            [buttons addObject:btn];
+        }
+    }
+
+    [[CPNowPlayingTemplate sharedTemplate] updateNowPlayingButtons:buttons];
+}
+
+- (void)updateCarPlayNowPlayingButtons API_AVAILABLE(ios(14.0)) {
+    refreshCarPlayNowPlayingButtons();
+}
+#endif
 
 @end

--- a/audio_service/darwin/audio_service/Sources/audio_service/AudioServicePlugin.m
+++ b/audio_service/darwin/audio_service/Sources/audio_service/AudioServicePlugin.m
@@ -220,6 +220,9 @@ static NSMutableDictionary *nowPlayingInfo = nil;
             }
         }
         [self updateNowPlayingInfo];
+        if (commandCenter) {
+            [self updateControl:ASetRating];
+        }
         result(@{});
     } else if ([@"setPlaybackInfo" isEqualToString:call.method]) {
         result(@{});
@@ -329,6 +332,70 @@ static NSMutableDictionary *nowPlayingInfo = nil;
 }
 
 - (void) updateControl:(enum MediaAction)action {
+    // ASetRating maps to multiple commands depending on the rating style.
+    if (action == ASetRating) {
+        if (!commandCenter) return;
+        BOOL enable = ((actionBits >> action) & 1);
+        NSDictionary *ratingDict = nil;
+        if (mediaItem != nil && mediaItem[@"rating"] != nil && mediaItem[@"rating"] != (id)[NSNull null]) {
+            ratingDict = mediaItem[@"rating"];
+        }
+        int ratingType = ratingDict ? [ratingDict[@"type"] intValue] : 0;
+
+        // Reset all rating-related commands before re-applying.
+        [commandCenter.likeCommand setEnabled:NO];
+        [commandCenter.dislikeCommand setEnabled:NO];
+        [commandCenter.ratingCommand setEnabled:NO];
+        [commandCenter.likeCommand removeTarget:nil];
+        [commandCenter.dislikeCommand removeTarget:nil];
+        [commandCenter.ratingCommand removeTarget:nil];
+
+        if (enable) {
+            switch (ratingType) {
+                case 1: // heart
+                    commandCenter.likeCommand.active = ratingDict && ratingDict[@"value"] != nil && ratingDict[@"value"] != (id)[NSNull null]
+                        ? [ratingDict[@"value"] boolValue]
+                        : NO;
+                    [commandCenter.likeCommand setEnabled:YES];
+                    [commandCenter.likeCommand addTarget:self action:@selector(like:)];
+                    break;
+                case 2: // thumbUpDown
+                    commandCenter.likeCommand.active = ratingDict && ratingDict[@"value"] != nil && ratingDict[@"value"] != (id)[NSNull null]
+                        ? [ratingDict[@"value"] boolValue]
+                        : NO;
+                    commandCenter.dislikeCommand.active = ratingDict && ratingDict[@"value"] != nil && ratingDict[@"value"] != (id)[NSNull null]
+                        ? ![ratingDict[@"value"] boolValue]
+                        : NO;
+                    [commandCenter.likeCommand setEnabled:YES];
+                    [commandCenter.dislikeCommand setEnabled:YES];
+                    [commandCenter.likeCommand addTarget:self action:@selector(like:)];
+                    [commandCenter.dislikeCommand addTarget:self action:@selector(dislike:)];
+                    break;
+                case 3: // range3stars  (maximumRating == ratingType index)
+                case 4: // range4stars
+                case 5: // range5stars
+                    commandCenter.ratingCommand.minimumRating = 0.0;
+                    commandCenter.ratingCommand.maximumRating = (float)ratingType;
+                    [commandCenter.ratingCommand setEnabled:YES];
+                    [commandCenter.ratingCommand addTarget:self action:@selector(changeRating:)];
+                    break;
+                case 6: // percentage
+                    commandCenter.ratingCommand.minimumRating = 0.0;
+                    commandCenter.ratingCommand.maximumRating = 100.0;
+                    [commandCenter.ratingCommand setEnabled:YES];
+                    [commandCenter.ratingCommand addTarget:self action:@selector(changeRating:)];
+                    break;
+                default:
+                    // No rating type specified: fallback to heart (likeCommand).
+                    commandCenter.likeCommand.active = NO;
+                    [commandCenter.likeCommand setEnabled:YES];
+                    [commandCenter.likeCommand addTarget:self action:@selector(like:)];
+                    break;
+            }
+        }
+        return;
+    }
+
     MPRemoteCommand *command = commands[action];
     if (command == (id)[NSNull null]) return;
     // Shift the actionBits right until the least significant bit is the tested action bit, and AND that with a 1 at the same position.
@@ -398,10 +465,7 @@ static NSMutableDictionary *nowPlayingInfo = nil;
             }
             break;
         case ASetRating:
-            // TODO:
-            // commandCenter.ratingCommand
-            // commandCenter.dislikeCommand
-            // commandCenter.bookmarkCommand
+            // Handled before this switch statement (multiple commands depending on rating style).
             break;
         case ASeekTo:
             if (@available(iOS 9.1, macOS 10.12.2, *)) {
@@ -566,6 +630,51 @@ static NSMutableDictionary *nowPlayingInfo = nil;
     }
     [handlerChannel invokeMethod:@"setShuffleMode" arguments:@{
         @"shuffleMode":@(modeIndex)
+    }];
+    return MPRemoteCommandHandlerStatusSuccess;
+}
+
+- (MPRemoteCommandHandlerStatus) like: (MPFeedbackCommandEvent *) event {
+    NSDictionary *ratingDict = nil;
+    if (mediaItem != nil && mediaItem[@"rating"] != nil && mediaItem[@"rating"] != (id)[NSNull null]) {
+        ratingDict = mediaItem[@"rating"];
+    }
+    int ratingType = ratingDict ? [ratingDict[@"type"] intValue] : 1;
+    NSDictionary *rating;
+    if (ratingType == 2) {
+        // thumbUpDown: like command = thumbs up
+        rating = @{@"type": @(2), @"value": @(YES)};
+    } else {
+        // heart: iOS toggles likeCommand.active before calling the handler
+        rating = @{@"type": @(1), @"value": @(commandCenter.likeCommand.active)};
+    }
+    [handlerChannel invokeMethod:@"setRating" arguments:@{
+        @"rating": rating,
+        @"extras": [NSNull null]
+    }];
+    return MPRemoteCommandHandlerStatusSuccess;
+}
+
+- (MPRemoteCommandHandlerStatus) dislike: (MPFeedbackCommandEvent *) event {
+    // thumbUpDown: dislike command = thumbs down (value = NO)
+    NSDictionary *rating = @{@"type": @(2), @"value": @(NO)};
+    [handlerChannel invokeMethod:@"setRating" arguments:@{
+        @"rating": rating,
+        @"extras": [NSNull null]
+    }];
+    return MPRemoteCommandHandlerStatusSuccess;
+}
+
+- (MPRemoteCommandHandlerStatus) changeRating: (MPRatingCommandEvent *) event {
+    NSDictionary *ratingDict = nil;
+    if (mediaItem != nil && mediaItem[@"rating"] != nil && mediaItem[@"rating"] != (id)[NSNull null]) {
+        ratingDict = mediaItem[@"rating"];
+    }
+    int ratingType = ratingDict ? [ratingDict[@"type"] intValue] : 5; // default range5stars
+    NSDictionary *rating = @{@"type": @(ratingType), @"value": @(event.rating)};
+    [handlerChannel invokeMethod:@"setRating" arguments:@{
+        @"rating": rating,
+        @"extras": [NSNull null]
     }];
     return MPRemoteCommandHandlerStatusSuccess;
 }

--- a/audio_service/pubspec.yaml
+++ b/audio_service/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_service
 description: Flutter plugin to play audio in the background while the screen is off.
-version: 0.18.18
+version: 0.18.19
 repository: https://github.com/ryanheise/audio_service/tree/minor/audio_service
 issue_tracker: https://github.com/ryanheise/audio_service/issues
 topics:


### PR DESCRIPTION
Rating was not implemented in iOS side.

This PR aim to fix that.

Add CarPlay NowPlaying button support for rating commands (like/dislike). When likeCommand or dislikeCommand is enabled via MediaAction.setRating, the corresponding CPNowPlayingImageButton (heart / thumbs-down with SF Symbols) is added to CPNowPlayingTemplate.shared. Tapping the button calls back setRating on the Flutter handler. CarPlay.framework is linked as a system framework on iOS 14+ and is a no-op when no CarPlay screen is connected and does not require the CarPlay entitlement.

MR was created using Sonnet 4.5 and GPT 5.3-codex. I tested my use case (like/dislike), which appears as a “star” on iOS and on CarPlay. This MR implements thumb, star range, and percentage rating formats, but as I’m not a primary iOS user, I’m unsure in which contexts these variants are used or how they behave.

I’m considering deploying this MR as-is to production on my side.

## Pre-launch Checklist

- [x] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [x] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [x] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I ran `dart analyze`.
- [x] I ran `dart format`.
- [x] I ran `flutter test` and all tests are passing.

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
