### PR TITLE
fix(android): Keep scheme of deep links on cold start

### DIFF
--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioServicePlugin.java
@@ -81,10 +81,7 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
                     if (activity.shouldHandleDeeplinking()) {
                         Uri data = activity.getIntent().getData();
                         if (data != null) {
-                            initialRoute = data.getPath();
-                            if (data.getQuery() != null && !data.getQuery().isEmpty()) {
-                                initialRoute += "?" + data.getQuery();
-                            }
+                            initialRoute = data.toString();
                         }
                     }
                 }
@@ -95,10 +92,7 @@ public class AudioServicePlugin implements FlutterPlugin, ActivityAware {
                     if (activity.shouldHandleDeeplinking()) {
                         Uri data = activity.getIntent().getData();
                         if (data != null) {
-                            initialRoute = data.getPath();
-                            if (data.getQuery() != null && !data.getQuery().isEmpty()) {
-                                initialRoute += "?" + data.getQuery();
-                            }
+                            initialRoute = data.toString();
                         }
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/100624

I suspect the old behavior was copied from Flutter back then.

See: https://github.com/flutter/flutter/blob/ae74cd8021191cdf60d2e8a9636cd76163c4a6e5/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java#L555

I also wonder, if there's a better way instead of replicating the Activity logic of Flutter, e.g. just reuse flutters engine instance?

## Pre-launch Checklist

- [x] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [x] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [ ] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I ran `dart analyze`.
- [ ] I ran `dart format`.
- [ ] I ran `flutter test` and all tests are passing.

<!-- Please consider also adding unit tests covering your new code. -->

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
