### PR TITLE
Prevent the resource shrinker from stripping the notification icons

### DIFF
--- a/audio_service/android/src/main/res/raw/keep.xml
+++ b/audio_service/android/src/main/res/raw/keep.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  The built-in MediaControl icons are resolved by name at runtime via
+  Resources.getIdentifier(), which the Android resource shrinker cannot see.
+  Without this rule it removes every audio_service_* drawable from release
+  builds, leaving the notification actions with icon id 0 so no transport
+  controls are drawn.
+-->
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@drawable/audio_service_*" />


### PR DESCRIPTION
## Problem

On release builds with Android resource shrinking enabled, the transport control buttons disappear from the notification entirely. The notification still renders its title, artist and artwork — there are simply no play/pause/next/previous buttons.

The built-in `MediaControl` icons are resolved by name at runtime via `getResources().getIdentifier(...)`. The resource shrinker cannot see that reference, so it removes all seven `audio_service_*` drawables. The actions are still added to the notification; they just end up with icon id `0`, so nothing is drawn.

## Evidence

Shrinker report from a release build (`build/app/outputs/mapping/release/resources.txt`):

```
drawable:audio_service_fast_forward:2131099648 is not reachable.
drawable:audio_service_fast_rewind:2131099649 is not reachable.
drawable:audio_service_pause:2131099650 is not reachable.
drawable:audio_service_play_arrow:2131099651 is not reachable.
drawable:audio_service_skip_next:2131099652 is not reachable.
drawable:audio_service_skip_previous:2131099653 is not reachable.
drawable:audio_service_stop:2131099654 is not reachable.
```

`aapt2 dump resources` on the resulting APK shows one drawable left in the entire package.

Meanwhile `dumpsys notification` shows the notification is otherwise perfectly well-formed — MediaStyle template, session token, three actions with their PendingIntents, compact action indices and a large icon are all present. That is what makes this hard to track down: every piece of data is correct, only the drawing is missing.

## Why it is easy to miss

On stock Android the system media controls draw their own buttons from the MediaSession, so the missing drawables are invisible there. It only surfaces on OEM shades that render MediaStyle notifications themselves — reproduced on vivo OriginOS (Android 16), where another player's notification shows a full set of controls and audio_service's shows none. It also only affects release builds, so it never appears during development.

## Fix

Ship a `keep.xml` with the library.

Verified on the affected device: with only this file added and no keep rule in the app, the shrinker report changes to `reachable from keep xml file` for all seven drawables and the controls appear.

One caveat worth noting: an app that defines its own `res/raw/keep.xml` will override the library's, since they merge as the same resource. Apps that already worked around this are unaffected, but the library's rule will not apply to them.
